### PR TITLE
Eight Fire Dragons to Three Fire Dragons

### DIFF
--- a/chapters/554.txt
+++ b/chapters/554.txt
@@ -20,7 +20,7 @@ The three fiery dragons soared freely - one paving the way ahead, the other two 
 
 Much of Ning Zhuo's spiritual awareness resided within this shrine, where the deity statue bore his own appearance. Controlling fire elements through the shrine elevated every fire-based spell he cast to a superior level of precision.
 
-Benefiting from the eight fire dragons that the Golden Core cultivator used to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. The Golden Core cultivator commanded the eight dragons while simultaneously managing the puppet army, maneuvering fluidly across the battlefield.
+Benefiting from the three fire dragons that he summoned with Golden Core level strength to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. He commanded the three dragons while simultaneously managing the puppet army, maneuvering fluidly across the battlefield
 
 Holding a single position might yield temporary local advantages, but moving across the battlefield allowed him to face weaker, scattered opponents. The fiery dragons' sustained attacks at the heart of the battlefield grew increasingly powerful until they eventually exhausted themselves entirely.
 

--- a/index.html
+++ b/index.html
@@ -155,7 +155,6 @@
 <b>Chapter 550: Divine Abilities Reign Supreme</b>
 <div class="local-timestamp"></div>
 </div>
-
 </div>
 </div>
 <script>

--- a/read/554/index.html
+++ b/read/554/index.html
@@ -58,7 +58,7 @@ The three fiery dragons soared freely - one paving the way ahead, the other two 
 <br/>
 Much of Ning Zhuo's spiritual awareness resided within this shrine, where the deity statue bore his own appearance. Controlling fire elements through the shrine elevated every fire-based spell he cast to a superior level of precision.<br/>
 <br/>
-Benefiting from the eight fire dragons that the Golden Core cultivator used to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. The Golden Core cultivator commanded the eight dragons while simultaneously managing the puppet army, maneuvering fluidly across the battlefield.<br/>
+Benefiting from the three fire dragons that he summoned with Golden Core level strength to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. He commanded the three dragons while simultaneously managing the puppet army, maneuvering fluidly across the battlefield<br/>
 <br/>
 Holding a single position might yield temporary local advantages, but moving across the battlefield allowed him to face weaker, scattered opponents. The fiery dragons' sustained attacks at the heart of the battlefield grew increasingly powerful until they eventually exhausted themselves entirely.<br/>
 <br/>


### PR DESCRIPTION
Chapter 554
Original:
> Benefiting from the **eight fire dragon**s that the Golden Core cultivator used to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. The Golden Core cultivator **commanded the eight dragons** while simultaneously managing the puppet army, maneuvering fluidly across the battlefield

Proposed change:
- "eight fire dragons" to "three fire dragons". In chapter 553, it's stated that Ning Zhuo could only summon 3 dragons
- "commanded the eight dragons" to "commanded the three dragons"
- Slight rewording required since the golden core cultivator is actually just Ning Zhuo
> Benefiting from the **three fire dragons** that he summoned with Golden Core level strength to open the battlefield, Ning Zhuo continually deployed mechanical puppets, reorganizing his forces. He **commanded the three dragons** while simultaneously managing the puppet army, maneuvering fluidly across the battlefield