### PR TITLE
Renamed Hidden Sun Manor to Hidden Yang Manor

### DIFF
--- a/chapters/576.txt
+++ b/chapters/576.txt
@@ -92,7 +92,7 @@ Having settled their plan, they continued onward, blending in with the rest of t
 
 Shortly thereafter, they arrived at a separate manor.
 
-Three bold characters adorned the plaque at its gate - Hidden Sun Manor.
+Three bold characters adorned the plaque at its gate - Hidden Yang Manor.
 
 The gray paper lion statues guarding the entrance noticed the group and immediately spoke, "Newly arrived male consorts?"
 

--- a/chapters/578.txt
+++ b/chapters/578.txt
@@ -26,7 +26,7 @@ Qing Yan nodded upon seeing Ning Zhuo, stood up, and walked directly to him. "A 
 
 "In the coming days, White Paper Immortal City will be under strict control. Both of you must be careful and avoid making any mistakes."
 
-"You should know, dealing with the steward of Hidden Sun Manor on your behalf cost me quite a fortune."
+"You should know, dealing with the steward of Hidden Yang Manor on your behalf cost me quite a fortune."
 
 "If you violate the city rules and end up imprisoned, I won't have the means to get you out again."
 
@@ -40,9 +40,9 @@ Qing Yan laughed gently. "Since you've already become a male consort, stay here 
 
 "With your Jiao family's foundational method, the Triple Furnace True Yang Scripture, you'll surely stand out among the male consorts. Perhaps in half a month's time, you’ll be promoted to the Vigorous Yang Residence."
 
-Ning Zhuo felt a slight stir in his heart. He inwardly pondered: "Vigorous Yang Residence? So, besides Hidden Sun Manor, there are other residences as well."
+Ning Zhuo felt a slight stir in his heart. He inwardly pondered: "Vigorous Yang Residence? So, besides Hidden Yang Manor, there are other residences as well."
 
-"And judging by Qing Yan's tone, the Vigorous Yang Residence seems to be of a higher rank than the Hidden Sun Manor."
+"And judging by Qing Yan's tone, the Vigorous Yang Residence seems to be of a higher rank than the Hidden Yang Manor."
 
 He was always sensitive to any new intelligence.
 

--- a/read/576/index.html
+++ b/read/576/index.html
@@ -130,7 +130,7 @@ Having settled their plan, they continued onward, blending in with the rest of t
 <br/>
 Shortly thereafter, they arrived at a separate manor.<br/>
 <br/>
-Three bold characters adorned the plaque at its gate - Hidden Sun Manor.<br/>
+Three bold characters adorned the plaque at its gate - Hidden Yang Manor.<br/>
 <br/>
 The gray paper lion statues guarding the entrance noticed the group and immediately spoke, "Newly arrived male consorts?"<br/>
 <br/>

--- a/read/578/index.html
+++ b/read/578/index.html
@@ -64,7 +64,7 @@ Qing Yan nodded upon seeing Ning Zhuo, stood up, and walked directly to him. "A 
 <br/>
 "In the coming days, White Paper Immortal City will be under strict control. Both of you must be careful and avoid making any mistakes."<br/>
 <br/>
-"You should know, dealing with the steward of Hidden Sun Manor on your behalf cost me quite a fortune."<br/>
+"You should know, dealing with the steward of Hidden Yang Manor on your behalf cost me quite a fortune."<br/>
 <br/>
 "If you violate the city rules and end up imprisoned, I won't have the means to get you out again."<br/>
 <br/>
@@ -78,9 +78,9 @@ Qing Yan laughed gently. "Since you've already become a male consort, stay here 
 <br/>
 "With your Jiao family's foundational method, the Triple Furnace True Yang Scripture, you'll surely stand out among the male consorts. Perhaps in half a month's time, you’ll be promoted to the Vigorous Yang Residence."<br/>
 <br/>
-Ning Zhuo felt a slight stir in his heart. He inwardly pondered: "Vigorous Yang Residence? So, besides Hidden Sun Manor, there are other residences as well."<br/>
+Ning Zhuo felt a slight stir in his heart. He inwardly pondered: "Vigorous Yang Residence? So, besides Hidden Yang Manor, there are other residences as well."<br/>
 <br/>
-"And judging by Qing Yan's tone, the Vigorous Yang Residence seems to be of a higher rank than the Hidden Sun Manor."<br/>
+"And judging by Qing Yan's tone, the Vigorous Yang Residence seems to be of a higher rank than the Hidden Yang Manor."<br/>
 <br/>
 He was always sensitive to any new intelligence.<br/>
 <br/>


### PR DESCRIPTION
Hidden Yang Manor is more accurate than the original Hidden Sun Manor. Since we've been going forward with Hidden Yang Manor in chapter 579, 580, and 581, it might be best to retcon past instances of Hidden Sun Manor to Hidden Yang Manor. 

- There shouldn't be any merge conflicts with this one. Thank you for handling it last time
- Excluded main index.html file