### PR TITLE
Clarification and consistency

### DIFF
--- a/chapters.json
+++ b/chapters.json
@@ -2504,7 +2504,7 @@
         "filename": "616.txt"
     },
     {
-        "title": "Chapter 617: Yang Third Eye, the Arrogant One",
+        "title": "Chapter 617: Yang Sanyan, the Arrogant One",
         "filename": "617.txt"
     },
     {

--- a/chapters/423.txt
+++ b/chapters/423.txt
@@ -234,7 +234,7 @@ The two newly designed spells, although not precisely controllable, were like ru
 
 Zhang Chongyi witnessed Ning Zhuo designing two brand new spells, his heart shocked, and exclaimed, "You are also a master of Fire and Wood elements?"
 
-"Could it be that you possess the Five Elements Transformation, or the talent of Wood-Fire-Earth Three Element Fate?"
+"Could it be that you possess the Scorched Earth Transformation, or the talent of Wood-Fire-Earth Three Element Fate?"
 
 Ning Zhuo chose to conceal part of it, saying, "I do have some talent, but it has never been fully assessed."
 

--- a/chapters/470.txt
+++ b/chapters/470.txt
@@ -104,7 +104,7 @@ Boss, if you hadn’t said that, we’d still be good friends!
 
 Seeing that Ning Zhuo remained silent for a long time, Sun Lingtong was driven by curiosity, “Aiya, Little Zhuo, hurry up and tell me.”
 
-Ning Zhuo could only nod and reluctantly say, “This military strategy is called… The Hero Returns Technique!”
+Ning Zhuo could only nod and reluctantly say, “This military strategy is called… The Hero's Return Technique!”
 
 “What does that mean?” Sun Lingtong was puzzled.
 

--- a/chapters/476.txt
+++ b/chapters/476.txt
@@ -234,7 +234,7 @@ Before, they had only been blurry human outlines—one could make out limbs and 
 
 “Little Zhuo, what if we join in the drilling? How would that go?” Sun Lingtong, witnessing this process, became eager to try.
 
-He had studied the “High Victory Writings” through a shared helmet with the soldiers, learning the Swift-Wind Thief Formation.
+He had studied Gao Sheng's Posthumous Writings through the Ancient Shared - Battle Armor, learning the Little Thief's Light Breeze Formation.
 
 Ning Zhuo thought a moment. “It would definitely be better to add another formation!”
 
@@ -258,16 +258,16 @@ They had already been troubled by the fact that their side had only two battle f
 
 Ning Zhuo volunteered, which delighted them, and they all agreed that Ning Zhuo would lead the training.
 
-Outwardly, Ning Zhuo gave the orders on behalf of Sun Lingtong. After five rounds, the soldiers were drilled in the Swift-Wind Thief Formation.
+Outwardly, Ning Zhuo gave the orders on behalf of Sun Lingtong. After five rounds, the soldiers were drilled in the Little Thief's Light Breeze Formation.
 
 “Strategist, what formation is this? Forgive my ignorance, I have never heard of such a thing,” Guan Hong asked in rare curiosity.
 
-Ning Zhuo replied that it was the “Light-Body Gale Formation,” which could increase the unit’s marching speed and aid in stealth.
+Ning Zhuo replied that it was the “Little Thief's Light Breeze Formation,” which could increase the unit’s marching speed and aid in stealth.
 
 Sun Lingtong, less skilled in military strategy than the three generals, continued drilling for five more rounds until it was fully mastered.
 
 Next, the three generals each practiced their respective arts again, which also caused minor transformations in the soldier-shadows.
 
-Ning Zhuo used this opportunity to practice his "The Hero Returns Again" Technique, drawing the three generals’ renewed curiosity, as they could not discern any visible effect from its use.
+Ning Zhuo used this opportunity to practice his "The Hero's Return Again" Technique, drawing the three generals’ renewed curiosity, as they could not discern any visible effect from its use.
 
 “Strategist, what did you just train?” they asked.

--- a/chapters/477.txt
+++ b/chapters/477.txt
@@ -104,7 +104,7 @@ Their army’s combat strength was too weak, definitely not a match for Ma Liang
 
 The three generals had already built trust with him and immediately yielded the leading position.
 
-Light Breeze of Thieves Formation!
+Little Thief's Light Breeze Formation!
 
 A gentle breeze swirled around, boosting the speed of the three generals’ camp.
 
@@ -112,11 +112,11 @@ Ning Zhuo directed the troops forward. He was not foolish enough to try crossing
 
 Ma Liangcai attacked again and again, but Ning Zhuo’s skillful maneuvering of the formation allowed the three generals’ camp to dodge the brunt of the offensive and gradually open up a gap.
 
-“How interesting. What formation is this?” It was the first time Ma Liangcai had seen the Light Breeze of Thieves Formation, and he was quite curious, so he asked at once.
+“How interesting. What formation is this?” It was the first time Ma Liangcai had seen the Little Thief's Light Breeze Formation, and he was quite curious, so he asked at once.
 
-Zhang Hei, using his loud voice, directly shouted back, “It’s the Swift Gale Lightening Formation! You don’t even know such a formation, Ma Liangcai? So you’re just that mediocre.”
+Zhang Hei, using his loud voice, directly shouted back, “It’s the Little Thief's Light Breeze Formation! You don’t even know such a formation, Ma Liangcai? So you’re just that mediocre.”
 
-“Swift Gale Lightening Formation?” Ma Liangcai nodded solemnly. “I’ll remember that.”
+“Little Thief's Light Breeze Formation?” Ma Liangcai nodded solemnly. “I’ll remember that.”
 
 With the help of this formation, the three generals’ camp greatly increased its marching speed.
 
@@ -348,7 +348,7 @@ A grand five-element spell struck the badly wounded Ma Liangcai, knocking him do
 
 “You? Who are you?” Ma Liangcai looked at the man whose presence was augmented by the army, his aura surging up to the Nascent Soul level. Ma Liangcai was stunned.
 
-The Hero Returning Spell!
+The Hero's Return Technique!
 
 Sun Lingtong laughed up at the sky, then fell backward onto the ground.
 

--- a/chapters/483.txt
+++ b/chapters/483.txt
@@ -110,13 +110,13 @@ Anything could happen in war.
 
 Ning Zhuo remembered the ambush well. Faced with the enemy’s sudden counterattack, he had no time to react, even in the midst of protective forces. Ever since then, Ning Zhuo had lost any sense of security.
 
-He now began practicing the “Light-Footed Whirlwind Formation.”
+He now began practicing the “Little Thief's Light Breeze Formation.”
 
-Oh no, it should be called the “Swift Wind Formation.”
+Oh no, it should be called the “Light Body Swift Wind Formation.”
 
 Before long, Ning Zhuo’s face turned pale. Fine beads of sweat appeared on his forehead, and his divine sense in his upper dantian was consumed violently.
 
-He was able to practice only thirty percent of the Swift Wind Formation before he could not keep going.
+He was able to practice only thirty percent of the Light Body Swift Wind Formation before he could not keep going.
 
 Under normal circumstances, soldiers following the formation’s instructions would move on their own.
 
@@ -154,7 +154,7 @@ Sun Lingtong’s divine sense was already quite excellent.
 
 He also had some ability to operate different mechanical devices. After all, he had started studying the mechanical classics left behind by Ning Zhuo’s mother a long time ago.
 
-But after Ning Zhuo had practiced the Swift Wind Formation briefly, he went on to a more important experiment.
+But after Ning Zhuo had practiced the Light Body Swift Wind Formation briefly, he went on to a more important experiment.
 
 Military Tactic —“Return of the Warrior” Technique!
 

--- a/chapters/488.txt
+++ b/chapters/488.txt
@@ -256,7 +256,7 @@ After another half cup of tea’s time, Sun and Ning had grown far more proficie
 
 They formed a battle array.
 
-The formation was —Lightfoot Gale Formation!
+The formation was — Light Body Swift Wind Formation!
 
 Working together, Sun and Ning joined forces to form the battle formation.
 
@@ -268,7 +268,7 @@ He deliberately exerted more spiritual energy, and at the last juncture, these t
 
 Boom.
 
-With a faint rumble, the Lightfoot Gale Formation succeeded.
+With a faint rumble, the Light Body Swift Wind Formation succeeded.
 
 Tiny gusts of wind swirled among the entire mechanical force, lifting and twining around the puppets, increasing their speed, making them agile, and rendering them nearly silent.
 

--- a/chapters/492.txt
+++ b/chapters/492.txt
@@ -148,7 +148,7 @@ The mechanical army poured down like a long river.
 
 The spear-wielding Golden Core led part of the remaining troops and launched ranged attacks on Ning Zhuo.
 
-Under the effect of the Lightfoot Gale Formation, Ning Zhuo’s mechanical army moved lightly and swiftly, evading much of the attack. They charged to the side of the Three Generals Battalion.
+Under the effect of the Light Body Swift Wind Formation, Ning Zhuo’s mechanical army moved lightly and swiftly, evading much of the attack. They charged to the side of the Three Generals Battalion.
 
 The dual-axe Golden Core, who was in the midst of besieging the Three Generals Battalion, became so enraged that he started cursing.
 

--- a/chapters/500.txt
+++ b/chapters/500.txt
@@ -258,7 +258,7 @@ There was no doubt that the Three Generals’ Camp was at a huge disadvantage.
 
 Liu Er began to direct the troops, forming a battle formation.
 
-In this situation, Ning Zhuo’s Lightfoot Gale Formation would have been ideal. Unfortunately, in daily drills, Ning Zhuo rarely participated, and the Three Generals’ Camp hadn’t practiced it much.
+In this situation, Ning Zhuo’s Light Body Swift Wind Formation would have been ideal. Unfortunately, in daily drills, Ning Zhuo rarely participated, and the Three Generals’ Camp hadn’t practiced it much.
 
 Hence, Liu Er chose the Triangular Arrow Formation, leaving Generals Guan and Zhang to occupy Wu Lan and Diao Ye for a moment while he stood at the heart of the formation, with Ning Zhuo at the formation’s pivot.
 

--- a/chapters/504.txt
+++ b/chapters/504.txt
@@ -78,7 +78,7 @@ Because of the large losses among his mechanical puppets, Ning Zhuo’s aura sur
 
 His eyes grew bloodshot, veins bulged at his temples and neck, and blood even began to trickle from the corner of his mouth.
 
-“Little Zhuo, your body’s reserves are shallow. With the Warrior’s Return Technique still boosting you, your flesh is close to its limit!” Sun Lingtong spotted danger at once through his spiritual eyes.
+“Little Zhuo, your body’s reserves are shallow. With the Hero's Return Technique still boosting you, your flesh is close to its limit!” Sun Lingtong spotted danger at once through his spiritual eyes.
 
 Ning Zhuo nodded. “There’s no other way. I’ll just give it a try.”
 

--- a/chapters/505.txt
+++ b/chapters/505.txt
@@ -136,9 +136,9 @@ Liu Er remarked, “Judging by the results, this probing attack by Commander Du 
 
 Ning Zhuo remained silent, reflecting on the intelligence regarding the current Elephant King.
 
-In his heart, he thought, "If I had a body like his, I could withstand more uses of the Heroic Return Technique and wouldn't have been in such a precarious situation against Di Lu."
+In his heart, he thought, "If I had a body like his, I could withstand more uses of the Hero's Return Technique and wouldn't have been in such a precarious situation against Di Lu."
 
-The Heroic Return Technique had immense potential.
+The Hero's Return Technique had immense potential.
 
 This battlefield technique, derived from the High Victory Codex, had been comprehended by Ning Zhuo with the aid of the Unified Helm of Warriors.
 
@@ -146,7 +146,7 @@ Both the High Victory Codex and the Unified Helm of Warriors were priceless trea
 
 However, Ning Zhuo's physical limitations restricted the technique's full potential.
 
-Reflecting on the previous battle, Ning Zhuo regretted not daring to include Yuan Dasheng and Meng Yehu in the Heroic Return Technique, fearing that his body would be overwhelmed and explode.
+Reflecting on the previous battle, Ning Zhuo regretted not daring to include Yuan Dasheng and Meng Yehu in the Hero's Return Technique, fearing that his body would be overwhelmed and explode.
 
 "Is there any way to rapidly enhance my physical foundation?"
 
@@ -154,7 +154,7 @@ Ning Zhuo was troubled.
 
 Upon returning to Forest Immortal City, he had purchased various war supplies, including talismans and elixirs to enhance his physical foundation.
 
-Yet, compared to what the Heroic Return Technique demanded, these were mere drops in the bucket.
+Yet, compared to what the Hero's Return Technique demanded, these were mere drops in the bucket.
 
 "If Commander Du bestows rewards for our accomplishments, perhaps I can request some high-grade elixirs or talismans?"
 
@@ -168,7 +168,7 @@ Thus, the nation's standard resources were no longer as effective.
 
 Ning Zhuo was more focused on enhancing his physical foundation.
 
-Ideally, he wanted to quickly meet the standard required to leverage the Heroic Return Technique, amplifying his combat power to the Nascent Soul level.
+Ideally, he wanted to quickly meet the standard required to leverage the Hero's Return Technique, amplifying his combat power to the Nascent Soul level.
 
 "War is fraught with peril.
 

--- a/chapters/514.txt
+++ b/chapters/514.txt
@@ -174,7 +174,7 @@ With this tally, Ning Zhuo’s expression became somewhat dazed.
 
 “Once all of them are unleashed, my combat power will completely surpass almost all Golden Core cultivators in the world, capable of contending with Nascent Soul level foes.”
 
-“What if I further combined the Life Hanging by a Thread Divine Ability and the Hero's Return Art, and received the backing of the national power and military might of the Two Note Nations... what would happen?”
+“What if I further combined the Life Hanging by a Thread Divine Ability and the Hero's Return Technique, and received the backing of the national power and military might of the Two Note Nations... what would happen?”
 
 “Hiss, I am so powerful!”
 

--- a/chapters/519.txt
+++ b/chapters/519.txt
@@ -42,7 +42,7 @@ Ning Zhuo was no exception.
 
 However, his cultivation of the art of warfare was far inferior to that of cultivators such as Liu, Guan, Zhang, Mu, and others.
 
-After continuous midnight meditation for an entire day and a half, Ning Zhuo not only gained a deeper understanding of the “Iron Flow Leveling the Plains” strategy but also a deeper comprehension of the Warrior’s Return Technique.
+After continuous midnight meditation for an entire day and a half, Ning Zhuo not only gained a deeper understanding of the “Iron Flow Leveling the Plains” strategy but also a deeper comprehension of the Hero's Return Technique.
 
 The progress in the latter was clearly more helpful to Ning Zhuo than that in the former. Sun Lingtong was the same.
 

--- a/chapters/528.txt
+++ b/chapters/528.txt
@@ -10,13 +10,13 @@ In their hands, most carried long spears, but some held swords and shields.
 
 The soldiers of the Three Generals Camp also turned their gaze toward these mechanical puppets, their expressions filled with astonishment.
 
-Guan Hong stroked his beard and communicated through divine sense, "According to the strategist’s wealth, he could very well manufacture these mechanical puppets to be even more exquisite. It appears that the strategist intends to use the Warrior’s Return Technique."
+Guan Hong stroked his beard and communicated through divine sense, "According to the strategist’s wealth, he could very well manufacture these mechanical puppets to be even more exquisite. It appears that the strategist intends to use the Hero's Return Technique."
 
 Ning Zhuo said, "General Guan, your martial eye is without error."
 
 Ning Zhuo, of course, could use metal as the primary material to manufacture mechanical puppets.
 
-However, firstly, the production time would be longer and the cost higher; secondly, in actual combat they would not be easily damaged, which would impede the effectiveness of the Warrior’s Return Technique; thirdly, the wood was sourced from Thousand Peaks Forest and Green Forest Immortal City, which were local specialties and relatively inexpensive, while metal was more expensive.
+However, firstly, the production time would be longer and the cost higher; secondly, in actual combat they would not be easily damaged, which would impede the effectiveness of the Hero's Return Technique; thirdly, the wood was sourced from Thousand Peaks Forest and Green Forest Immortal City, which were local specialties and relatively inexpensive, while metal was more expensive.
 
 Before departing, Liu Er walked to Ning Zhuo’s side, grabbed his hands, and with concern admonished, "The strategist going out alone is because of our own incompetence!"
 
@@ -297,7 +297,7 @@ Yan Jin learned of Ning Zhuo’s information, but the combat strength the latter
 
 It was not that Ning Zhuo had previously concealed his strength, but that he himself had advanced at a truly rapid pace during this period.
 
-All along, his Warrior’s Return Technique had been constrained by his physical foundation, making it difficult to fully empower.
+All along, his Hero's Return Technique had been constrained by his physical foundation, making it difficult to fully empower.
 
 But by employing the demonic methods of the Fetal Breath Spirit Boat, Ning Zhuo’s physical foundation skyrocketed, making him incomparable to his former self.
 The destruction of over five hundred mechanical puppets not only propelled his combat strength to the Golden Core Level, but also far surpassed his previous peak, making him a top-tier figure at the Golden Core Stage!

--- a/chapters/529.txt
+++ b/chapters/529.txt
@@ -38,7 +38,7 @@ Ning Zhuo grew even more excited.
 
 “So, could I really be this powerful?”
 
-“It was all because my physical foundation had grown far stronger, allowing me to receive further augmentations from the Warrior’s Return Technique and Martial Strategy.”
+“It was all because my physical foundation had grown far stronger, allowing me to receive further augmentations from the Hero's Return Technique and Martial Strategy.”
 
 “The stronger my strength, the greater the might of my spells.”
 

--- a/chapters/534.txt
+++ b/chapters/534.txt
@@ -96,7 +96,7 @@ In the span of a single breath, the mechanical ring in Ning Zhuo’s hand gave h
 
 However, even though Ning Zhuo evaded the first strike, he was still in danger. He had just rolled about three steps away, and then icy mist appeared on both his left and right sides, from which two white bone skeletons emerged. The three skeletons all emanated an aura of Golden Core level and launched an assault on Ning Zhuo.
 
-In a critical moment, Ning Zhuo frantically dodged, while also summoning his mechanical fists and kicks to cover his defensive gaps. The aid of the Warrior’s Return Technique had already raised his combat power to the Golden Core level. The close-combat techniques he had diligently practiced in the Myriad Medicine Sect enabled him to evade most of the attacks. 
+In a critical moment, Ning Zhuo frantically dodged, while also summoning his mechanical fists and kicks to cover his defensive gaps. The aid of the Hero's Return Technique had already raised his combat power to the Golden Core level. The close-combat techniques he had diligently practiced in the Myriad Medicine Sect enabled him to evade most of the attacks. 
 
 For the remaining assaults, he relied on his mechanical fists and boots to compensate for the gaps in his defense.
 

--- a/chapters/540.txt
+++ b/chapters/540.txt
@@ -185,11 +185,11 @@ But now, he had made a critical, massive breakthrough!
 
 This was logically justifiable.
 
-Ning Zhuo’s flesh foundation had been continuously improving, allowing him to be empower more by the Hero's return technique.
+Ning Zhuo’s flesh foundation had been continuously improving, allowing him to be empower more by the Hero's Return Technique.
 
 Since the battle began, he had almost lost all his mechanical puppets, with his stock already dropping below a hundred.
 
-He had even released the heavily armored Blood Ape: Dasheng; the loss of this Golden Core level mechanism was also within the scope of the Hero's return techniques!
+He had even released the heavily armored Blood Ape: Dasheng; the loss of this Golden Core level mechanism was also within the scope of the Hero's Return Technique!
 
 On one hand, it was Ning Zhuo’s own strength that had been leveraged to an unprecedented degree by the Gao Sheng’s Posthumous Writings.
 

--- a/chapters/553.txt
+++ b/chapters/553.txt
@@ -142,7 +142,7 @@ The appearance of this new arrival went unnoticed amid the ongoing action.
 
 On the chaotic battlefield, among the cultivators and armies, they interlocked like teeth, each fighting their own battles. 
 
-Battle Formation - Swift Wind Formation!
+Light Body Swift Wind Formation!
 
 The mechanical puppets formed a battle formation; their speed suddenly increasing, becoming extremely nimble.
 
@@ -200,7 +200,7 @@ Whatever mechanical puppets were lost, Ning Zhuo immediately replenished.
 
 Rich in resources and backed by his mechanical pedestals solving his production issue, Ning Zhuo had an abundant reserve of mechanical puppets.
 
-Military Art - Heroic Return Technique!
+Military Art - Hero's Return Technique!
 
 Ning Zhuo still hadn't fully grasped the profundities of this art, derived from the exquisite integration of "Shared Battle Armor Technique" and "Gao Sheng's Posthumous Writings", vastly superior to ordinary military arts.
 
@@ -256,4 +256,4 @@ The number of fire dragons corresponded to the cultivator’s level. Normally, N
 
 Under the relentless blaze, the wolf army was utterly annihilated. Ning Zhuo pressed forward relentlessly.
 
-Empowered by the Heroic Return Technique, his strength continued to climb rapidly!
+Empowered by the Hero's Return Technique, his strength continued to climb rapidly!

--- a/chapters/554.txt
+++ b/chapters/554.txt
@@ -72,7 +72,7 @@ Lone Fang is no exception, nor is the Lord of the Blood Shadow Cave!”
 
 “Fortunately, I’m positioned in the mid-zone rather than at the battlefield’s core.”
 
-Recently, Ning Zhuo had been diligently cultivating within the Embryonic Breath Spirit Boat, dramatically strengthening his physical foundation, allowing him to sustain greater enhancements from the Warrior's Return Technique.
+Recently, Ning Zhuo had been diligently cultivating within the Embryonic Breath Spirit Boat, dramatically strengthening his physical foundation, allowing him to sustain greater enhancements from the Hero's Return Technique.
 
 However, from the recent battles, it was clear that the baseline of combat power for Golden Core cultivators remained around Ning Zhuo’s level. 
 
@@ -144,7 +144,7 @@ Three-layered Flame Shield!
 
 Earthen Armor, Rock Barrier!
 
-Protective fire and earth elemental spells enhanced his defenses, while the Warrior's Return Technique steadily boosted Ning Zhuo’s combat power.
+Protective fire and earth elemental spells enhanced his defenses, while the Hero's Return Technique steadily boosted Ning Zhuo’s combat power.
 
 Vines erupted from underground, immediately strangling a dozen barbarian cultivators.
 

--- a/chapters/555.txt
+++ b/chapters/555.txt
@@ -60,7 +60,7 @@ Since childhood, he had been contemplating ways to deal with the City Lord’s M
 
 Ning Zhuo remained expressionless, his heart undisturbed. In just a short while, his aura had strengthened even further.
 
-He had already anticipated the exposure of such information after repeatedly using the Hero’s Return Art in battle.
+He had already anticipated the exposure of such information after repeatedly using the Hero’s Return Technique in battle.
 
 His main focus was on controlling his mechanical constructs.
 
@@ -178,9 +178,9 @@ Even the thick layer of Earth Armor clinging to his body immediately began to we
 
 This mechanical armor stood firm and unmoved, glowing faintly with Buddhist light, displaying its formidable defensive power.
 
-Ning Zhuo couldn’t unleash the Profound Gold Slash - several of his defensive spells had been broken, and his spiritual power had been drained significantly.
+Ning Zhuo couldn’t unleash the Mystic Gold Slash - several of his defensive spells had been broken, and his spiritual power had been drained significantly.
 
-If he forcefully unleashed the Profound Gold Slash now, it would no doubt drain all his spiritual energy!
+If he forcefully unleashed the Mystic Gold Slash now, it would no doubt drain all his spiritual energy!
 
 In this kind of situation, the better option was to activate a magical tool or magical artifact - that would save far more spiritual energy.
 
@@ -188,7 +188,7 @@ Foundation Establishment cultivators generally relied on magical tools. Even tho
 
 And that difference… lay exactly here.
 
-His spiritual energy hadn’t undergone the fundamental transformation that came with forming a golden core. If he used a magical treasure, the consumption would be enormous - practically no different from forcefully casting the Profound Gold Slash.
+His spiritual energy hadn’t undergone the fundamental transformation that came with forming a golden core. If he used a magical treasure, the consumption would be enormous - practically no different from forcefully casting the Mystic Gold Slash.
 
 So, Ning Zhuo chose to use a magical tool instead.
 

--- a/chapters/558.txt
+++ b/chapters/558.txt
@@ -144,11 +144,11 @@ Just this one change alone led to a complete reversal of the battle situation! A
 
 Just a moment before, both sides had been evenly matched - even favoring The Thousand Peaks Forest’s side, who were still pressing forward aggressively. But in the very next moment, the counterattack erupted, and The Thousand Peaks Forest’s suddenly found themselves at a clear defensive disadvantage.
 
-Inside the dragon-head command cabin, Sun Lingtong wore a look of sudden realization and murmured to himself, “Thief's Gentle Breeze Formation… So that’s how it is.”
+Inside the dragon-head command cabin, Sun Lingtong wore a look of sudden realization and murmured to himself, “Little Thief's Light Breeze Formation… So that’s how it is.”
 
 Triggered by this moment, and relying on his extraordinary perception, he instantly grasped the full essence of the battle formation he had previously comprehended.
 
-From this moment on, he had fully understood the Thief’s Gentle Breeze Formation - he had completely mastered the core and essence of this formation.
+From this moment on, he had fully understood the Little Thief's Light Breeze Formation - he had completely mastered the core and essence of this formation.
 
 He could now once again activate Gao Sheng's Writings and the Shared Helm of Generals.
 
@@ -284,11 +284,11 @@ Ning Zhuo's mechanical puppets were swept up by a fierce wind and sucked into th
 
 Ning Zhuo's expression changed abruptly, a faint fear gripping his heart. He realized that losing these mechanical puppets hadn’t given him any boost whatsoever.
 
-“This method precisely counters my Warrior's Return Technique!” Ning Zhuo exclaimed in astonishment.
+“This method precisely counters my Hero's Return Technique!” Ning Zhuo exclaimed in astonishment.
 
 There were no strongest spells, only strongest cultivators.
 
-Everything in the world had mutual reinforcement and restraint; this was the principle of natural balance. Ning Zhuo’s Warrior’s Return Technique, which he had always relied on, naturally had its moment of being countered.
+Everything in the world had mutual reinforcement and restraint; this was the principle of natural balance. Ning Zhuo’s Hero's Return Technique, which he had always relied on, naturally had its moment of being countered.
 
 That moment, however, had come sooner than expected.
 

--- a/chapters/559.txt
+++ b/chapters/559.txt
@@ -128,7 +128,7 @@ Helplessly sighing, the Black Tortoise commander could only fully focus on guard
 
 A direct confrontation with the Black Tortoise Army would have been highly risky.
 
-After all, this was one of the top three armies within the Thousand Peaks Forest. Ning Zhuo’s Mechanical Army mainly served as disposable materials for the Heroic Return Technique, while his Three-Generals Battalion had only recently been established. Even though the Red Flower Battalion was renowned, it had always been undermanned and thus weaker overall compared to the Black Tortoise Army.
+After all, this was one of the top three armies within the Thousand Peaks Forest. Ning Zhuo’s Mechanical Army mainly served as disposable materials for the Hero's Return Technique, while his Three-Generals Battalion had only recently been established. Even though the Red Flower Battalion was renowned, it had always been undermanned and thus weaker overall compared to the Black Tortoise Army.
 
 They could fight, but victory would be uncertain and losses heavy - even if they won, it would only be a pyrrhic victory.
 

--- a/chapters/560.txt
+++ b/chapters/560.txt
@@ -114,7 +114,7 @@ His previous displays of coughing blood and agony were purely feigned.
 
 "Strategist, truly impressive!" Zhang Hei enthusiastically raised a thumb, despite his exhaustion.
 
-Just as Jin Tunhe countered Ning Zhuo’s "Warriors Return Technique," Ning Zhuo’s Fire Heart Temple precisely countered Demon Heart Cave Master's lethal technique.
+Just as Jin Tunhe countered Ning Zhuo’s "Hero's Return Technique," Ning Zhuo’s Fire Heart Temple precisely countered Demon Heart Cave Master's lethal technique.
 
 The white-robed youth’s heart had long been transformed, significantly mitigating the effects of the demon’s assault.
 
@@ -298,13 +298,13 @@ Yet, the Demon Heart Cave Master was different.
 
 “I still have a backup heart!” Just as the Demon Heart Cave Master gloated, Ning Zhuo suddenly opened his mouth and released another attack.
 
-Metal Element - Profound Gold Slash!
+Metal Element - Mystic Gold Slash!
 
 Metal Element - Temple of the Metal Lung!
 
 Channeling all his power into this final strike!
 
-The Profound Gold Slash shot into the Demon Heart Cave Master's open wound at lightning speed, entering his body and obliterating all his internal organs.
+The Mystic Gold Slash shot into the Demon Heart Cave Master's open wound at lightning speed, entering his body and obliterating all his internal organs.
 
 “How can such a domineering, straightforward Metal Art even bend?!” The Demon Heart Cave Master fell into total shock.
 

--- a/chapters/572.txt
+++ b/chapters/572.txt
@@ -76,15 +76,15 @@ Countless corpses piled high at the base of the walls, while atop the battlement
 
 As the fortress gates swung open, several sleek ships crafted from reddish hardwood burst forth.
 
-Of the cultivators piloting these vessels, only a small fraction were human; the majority belonged to the Ghost Tribe.
+Of the cultivators piloting these vessels, only a small fraction were human; the majority belonged to the Ghostman Tribe.
 
-Members of the Ghost Tribe were intelligent beings, half-human and half-ghost. The males typically had fierce and horrifying appearances, while the females were stunningly beautiful. Their skin varied wildly, spanning shades of crimson, emerald, sapphire, ebony, ivory, and golden hues.
+Members of the Ghostman Tribe were intelligent beings, half-human and half-ghost. The males typically had fierce and horrifying appearances, while the females were stunningly beautiful. Their skin varied wildly, spanning shades of crimson, emerald, sapphire, ebony, ivory, and golden hues.
 
 Their eyes were particularly striking, with black sclera surrounding eerily pale pupils - an attribute that allowed them to clearly perceive spirits.
 
 Each hardwood vessel was etched with intricate forbidden runes, fashioned as formidable warships, each propelled by twenty lengthy oars. Both bow and stern curved dramatically upwards, sculpted into the likeness of dragons’ heads and tails.
 
-The human cultivators aboard remained silent and grim-faced, anxiety clearly visible. In stark contrast, the Ghost Tribe cultivators loudly shouted, their wild hair whipping in the wind, limbs exposed, and heads crowned with sharp horns.
+The human cultivators aboard remained silent and grim-faced, anxiety clearly visible. In stark contrast, the Ghostman Tribe cultivators loudly shouted, their wild hair whipping in the wind, limbs exposed, and heads crowned with sharp horns.
 
 The three warships sped uniformly across the river, creating an intriguing spectacle that drew the curiosity of Sun and Ning. Where could these local cultivators be rushing off to so urgently?
 
@@ -94,7 +94,7 @@ However, seeing this unexpected urgency, the pair swiftly deliberated and chose 
 
 From their lofty vantage point, it wasn’t long before they spotted signs of recent battle. The river ahead was strewn with the wreckage of numerous ships and the massive carcasses of Bone-Chilling Crocodiles, several as large as war elephants, each radiating the oppressive aura of Foundation Establishment-level beasts.
 
-Most conspicuous among them was one crocodile corpse, belly-up and drifting on the current. It was enormous, easily two or three times the size of the warships dispatched from the Ghost Tribe’s village. Its hide was ravaged by wounds, its blood staining the river red.
+Most conspicuous among them was one crocodile corpse, belly-up and drifting on the current. It was enormous, easily two or three times the size of the warships dispatched from the Ghostman Tribe’s village. Its hide was ravaged by wounds, its blood staining the river red.
 
 This scene unmistakably spoke of a fierce battle, with catastrophic losses on both sides.
 
@@ -108,11 +108,11 @@ Their tiny Ten Thousand Li Dragon slipped quietly amidst the chaos unnoticed - t
 
 Carefully selecting two corpses whose injuries were less severe and whose garments were plain, they swiftly stashed them inside their dragon construct.
 
-Within moments, Sun Lingtong skillfully invoked his Thief Art, meticulously molding their appearances to match the deceased. Shortly afterward, Ning Zhuo had transformed into a freckled, yellow-faced human youth, while Sun Lingtong took the guise of a stout and diminutive Ghost Tribe member.
+Within moments, Sun Lingtong skillfully invoked his Thief Art, meticulously molding their appearances to match the deceased. Shortly afterward, Ning Zhuo had transformed into a freckled, yellow-faced human youth, while Sun Lingtong took the guise of a stout and diminutive Ghostman Tribe member.
 
 Exiting the dragon construct, Ning Zhuo feigned unconsciousness as Sun Lingtong, pretending to barely hold on, struggled through the water clutching Ning Zhuo. They were quickly spotted by the exhausted cultivators.
 
-“There's a Ghost Tribe member over here!”
+“There's a Ghostman Tribe member over here!”
 
 “That boy is the Jia family’s third son, Jiao Ma!”
 
@@ -132,17 +132,17 @@ And indeed, Ning Zhuo’s act was flawless. Having been meticulously trained by 
 
 Meanwhile, thanks to the Evil God's Bone Marrow, Sun Lingtong's Thief Art had greatly increased in potency, making their impersonation seamless and utterly convincing.
 
-Ning Zhuo, disguised as Scorched Numbskin, was warmly greeted by many who recognized him, showering him with care and concern. However, Sun Lingtong, who portrayed a member of the Short-legged Ghost Tribe, was completely ignored.
+Ning Zhuo, disguised as Scorched Numbskin, was warmly greeted by many who recognized him, showering him with care and concern. However, Sun Lingtong, who portrayed a member of the Short-legged Ghostman Tribe, was completely ignored.
 
 In any case, the surrounding cultivators quickly accepted them without the slightest hint of suspicion.
 
-Shortly after, three reinforcement warships arrived, rescuing the survivors. The leader, a Golden Core-level ghost cultivator, wore a grim expression. "This river section has always been safe. How could a swarm of Bone-Chilling Crocodiles suddenly appear?"
+Shortly after, three reinforcement warships arrived, rescuing the survivors. The leader, a Golden Core-level ghostman cultivator, wore a grim expression. "This river section has always been safe. How could a swarm of Bone-Chilling Crocodiles suddenly appear?"
 
 He sent scouts to investigate but found nothing suspicious.
 
-The Golden Core ghost cultivator then personally questioned the survivors, including Ning Zhuo and Sun Lingtong, but learned nothing of value.
+The Golden Core ghostman cultivator then personally questioned the survivors, including Ning Zhuo and Sun Lingtong, but learned nothing of value.
 
-When questioning Ning Zhuo, the leader personally cast a healing spell on him and offered words of comfort. Ning Zhuo quickly sensed that he and this ghost leader shared a significant relationship.
+When questioning Ning Zhuo, the leader personally cast a healing spell on him and offered words of comfort. Ning Zhuo quickly sensed that he and this ghostman leader shared a significant relationship.
 
 Proactively, Ning Zhuo suggested returning to the village to reconsider the situation. The Golden Core leader stared at him thoughtfully, noticing something unusual in Ning Zhuo's tone but didn't suspect much, only shaking his head gravely.
 
@@ -162,9 +162,9 @@ Sun Lingtong nodded subtly. "Sounds good."
 
 They secretly communicated through divine sense while outwardly following the group onto the warship.
 
-"Scorched Numbskin, come here," the Golden Core ghost leader suddenly beckoned to Ning Zhuo.
+"Scorched Numbskin, come here," the Golden Core ghostman leader suddenly beckoned to Ning Zhuo.
 
-Curious, Ning Zhuo approached him. The leader handed him a treasure, sighing softly, "You risked your life picking a Ghost-faced Banyan fruit for my daughter. Unfortunately, you've been chosen as the male consort for Whitepaper City's lord. Our village is too weak to defy Whitepaper City's orders."
+Curious, Ning Zhuo approached him. The leader handed him a treasure, sighing softly, "You risked your life picking a Ghost-faced Banyan fruit for my daughter. Unfortunately, you've been chosen as the male consort for Whitepaper City's lord. Our village is too weak to defy White Paper City's orders."
 
 "Fate does not favor your union with my daughter. Accept this - a Golden Core-level Bone-Chilling Crocodile's stomach I've personally refined for you. Later, you must let your soul enter and endure its corrosion before recovering. It will greatly enhance your soul's resilience."
 

--- a/chapters/573.txt
+++ b/chapters/573.txt
@@ -4,7 +4,7 @@ Thus, Ning Zhuo and Sun Lingtong secretly revised their previous plan, joining t
 
 Within the Ghostly Black Marshlands, waterways were abundant and intricate. The three redwood warships carried many people, who were all locals that were familiar with the environment, which made their journey smooth and uneventful throughout the day.
 
-Ning Zhuo hadn't yet learned the Ghost Tribe leader's full name, only knowing his surname was Qing from overhearing others. Coupled with the leader's pale green complexion, it seemed rather fitting.
+Ning Zhuo hadn't yet learned the Ghostman Tribe leader's full name, only knowing his surname was Qing from overhearing others. Coupled with the leader's pale green complexion, it seemed rather fitting.
 
 Since Leader Qing had already made arrangements, Ning Zhuo was placed directly under his care. Qing suggested Ning Zhuo use the Bone-chilling Crocodile stomach bag to recuperate, offering to personally protect him.
 
@@ -18,15 +18,15 @@ He kept a stern expression, addressing the Golden Core leader by surname alone, 
 
 "Leader Qing, once we reach White Paper City, I'll naturally use the stomach bag to rest. There's no need for you to trouble yourself so much on my behalf."
 
-Ironically, the Golden Core Ghost Tribe leader felt reassured, chuckling knowingly, "Jiao Ma, don't think I don't understand your thoughts. You're still thinking about my daughter and afraid you'll owe me a favor that's tough to repay."
+Ironically, the Golden Core Ghostman Tribe leader felt reassured, chuckling knowingly, "Jiao Ma, don't think I don't understand your thoughts. You're still thinking about my daughter and afraid you'll owe me a favor that's tough to repay."
 
 "Hmph."
 
-"You're a human, and my daughter is of the Ghost Tribe. A union between you two would hardly lead to happiness."
+"You're a human, and my daughter is of the Ghostman Tribe. A union between you two would hardly lead to happiness."
 
 "And what's wrong with becoming a male consort? If you become the City Lord’s husband, wealth and power would come effortlessly."
 
-The Ghost Tribe Golden Core didn't miss a chance to persuade Ning Zhuo.
+The Ghostman Tribe Golden Core didn't miss a chance to persuade Ning Zhuo.
 
 Beside him, Sun Lingtong struggled to hold back laughter, chiming in mockingly, "Indeed, Young Master Jiao Ma. Becoming a male consort is a rare opportunity that others can't even dream of."
 
@@ -34,11 +34,11 @@ Ning Zhuo snorted coldly, pointing sharply at Sun Lingtong, "Who are you again? 
 
 Sun Lingtong froze on the spot.
 
-Although the Ghost Tribe's numbers in the Ghostly Black Marshlands surpassed those of humans, their status remained inferior.
+Although the Ghostman Tribe's numbers in the Ghostly Black Marshlands surpassed those of humans, their status remained inferior.
 
-In the broader cultivation world, humans unquestionably dominated. The Ghost Tribe was sparse, significant only within this marshland.
+In the broader cultivation world, humans unquestionably dominated. The Ghostman Tribe was sparse, significant only within this marshland.
 
-Therefore, Ning Zhuo, as a human, ordering a Ghost Tribe Foundation Establishment cultivator to slap himself wasn't out of place.
+Therefore, Ning Zhuo, as a human, ordering a Ghostman Tribe Foundation Establishment cultivator to slap himself wasn't out of place.
 
 Leader Qing's eyes flickered subtly but said nothing.
 
@@ -46,7 +46,7 @@ Suddenly, a dozen gazes landed on Sun Lingtong.
 
 Gritting his teeth, Sun Lingtong glared at Ning Zhuo, prepared to strike himself when Ning Zhuo raised a hand to stop him. "But who am I?"
 
-"I am Jiao Ma, magnanimous and open-minded, not like some who hold petty biases between humans and ghosts."
+"I am Jiao Ma, magnanimous and open-minded, not like some who hold petty biases between humans and ghostmen."
 
 Leader Qing chuckled softly, understanding Ning Zhuo was indirectly mocking him. Remembering Ning Zhuo's pursuit of his daughter, Qing chose not to retaliate.
 
@@ -70,9 +70,9 @@ He hadn’t expected Ning Zhuo to be so audacious as to demand servitude from hi
 
 Yet, Sun Lingtong knew Ning Zhuo's true intention was to position him nearby for easier coordination of their future actions.
 
-Seeing Ning Zhuo successfully subdue a Ghost Tribe member, Leader Qing extended his spiritual sense, scanning Sun Lingtong thoroughly.
+Seeing Ning Zhuo successfully subdue a Ghostman Tribe member, Leader Qing extended his spiritual sense, scanning Sun Lingtong thoroughly.
 
-“Having a mid-stage Foundation Establishment ghost cultivator as your servant is acceptable,” Elder Qing nodded slightly. “Though, he's a bit too poor.”
+“Having a mid-stage Foundation Establishment ghostman cultivator as your servant is acceptable,” Elder Qing nodded slightly. “Though, he's a bit too poor.”
 
 With that, he produced two magical artifacts and tossed them to Sun Lingtong.
 

--- a/chapters/574.txt
+++ b/chapters/574.txt
@@ -118,15 +118,15 @@ Truthfully, each River Ghost possessed less than sixty percent of a Piercing Bon
 
 Qing Yan burst from the water’s surface, soaring into the air to cast two potent defensive spells onto the three battleships, barely stabilizing the dire situation.
 
-“Yin Soldiers? So you’re from one of the Netherworld courts?” Qing Yan’s expression turned grave, filled with anger and apprehension. “Is the Netherworld again interfering in the affairs of the mortal realm?”
+“Yin Soldiers? So you’re from one of the Underworld courts?” Qing Yan’s expression turned grave, filled with anger and apprehension. “Is the Underworld again interfering in the affairs of the mortal realm?”
 
-The Bone-armored Crocodile Demon emerged from the waters once more, his armor now cracked and broken in many places, and the crocodile mount beneath him replaced entirely. He pointed arrogantly at Qing Yan and sneered, “Even if I told you which Netherworld court it was, what could you possibly do about it? Our City Overthrowing Alliance is far more powerful than you’ve imagined!”
+The Bone-armored Crocodile Demon emerged from the waters once more, his armor now cracked and broken in many places, and the crocodile mount beneath him replaced entirely. He pointed arrogantly at Qing Yan and sneered, “Even if I told you which Underworld court it was, what could you possibly do about it? Our City Overthrowing Alliance is far more powerful than you’ve imagined!”
 
 “Qing Yan, if you kneel and beg now, perhaps I’ll spare your pitiful life.”
 
-Xie Sichao, still unseen, leisurely retorted, “We know very well the boundary between Yin and Yang. We have no interest in fully occupying the mortal realm or repeating past wars. The Ghostly Black Marshlands already closely resembles the Netherworld. It’s merely a little window through which we Netherworld cultivators wish to take a breath of fresh air - surely that’s permissible?”
+Xie Sichao, still unseen, leisurely retorted, “We know very well the boundary between Yin and Yang. We have no interest in fully occupying the mortal realm or repeating past wars. The Ghostly Black Marshlands already closely resembles the Underworld. It’s merely a little window through which we Underworld cultivators wish to take a breath of fresh air - surely that’s permissible?”
 
-Qing Yan glared at the Crocodile Demon with undisguised disgust. “You mortals collaborating with Netherworld powers - you’re utterly shameless!”
+Qing Yan glared at the Crocodile Demon with undisguised disgust. “You mortals collaborating with Underworld powers - you’re utterly shameless!”
 
 “Shameless?” The Crocodile Demon scoffed, murderous intent blazing. “For the sake of freedom and the purity of this land, our City Overthrowing Alliance must make sacrifices. Reputation is only one of them. This is our conviction!”
 

--- a/chapters/575.txt
+++ b/chapters/575.txt
@@ -182,7 +182,7 @@ White Paper City shone entirely pale, its walls not of stone nor wood, but curio
 
 The grand city gate stood impressively tall and thick, adorned with mystical inscriptions from the "Heavy Yin Tidewater Technique," emitting rhythmic, tide-like sounds.
 
-City guards primarily consisted of ghost clansmen, though their leaders and elites were humans. Their armor and weapons were uniquely crafted, resembling carefully folded white paper.
+City guards primarily consisted of ghostman clansmen, though their leaders and elites were humans. Their armor and weapons were uniquely crafted, resembling carefully folded white paper.
 
 "State your names," ordered the guard at the gate, a scholar cultivator holding a brush and book, cloaked in scholarly qi.
 

--- a/chapters/577.txt
+++ b/chapters/577.txt
@@ -28,7 +28,7 @@ A lingering melancholy overcame Ning Zhuo.
 
 Next came the Wheel of Reincarnation Black Algae Rolls.
 
-These were made from sheets of dry yellow tofu skin wrapped around black algae harvested from the Netherworld River.
+These were made from sheets of dry yellow tofu skin wrapped around black algae harvested from the Underworld River.
 
 Nibbling slightly, Ning Zhuo grimaced instantly. The tofu skin was bland and papery, akin to biting into layer upon layer of charm paper. The algae itself was unbearably salty, nearly causing him to spit out his own tongue in disgust.
 
@@ -80,13 +80,13 @@ By the time Ning Zhuo had finished the meal, he was delighted to discover that t
 
 After lunch, most of the veteran male consorts departed the dining hall, leaving only Ning Zhuo and the other newcomers behind.
 
-At this point, Sun Lingtong emerged quietly from his corner, transmitting a message discreetly with his divine sense, "I just spoke with other ghost-servants here. They mentioned that when their masters first arrived, they generously bribed the elderly steward."
+At this point, Sun Lingtong emerged quietly from his corner, transmitting a message discreetly with his divine sense, "I just spoke with other ghostman servants here. They mentioned that when their masters first arrived, they generously bribed the elderly steward."
 
 "For newcomers like us, the sort of living arrangements we get assigned now could be absolutely crucial."
 
 “Perhaps we could imitate them and strive for a large residence ourselves?”
 
-The male consorts were mostly humans, with very few ghosts among them, creating a distinct division between newcomers and veterans. The atmosphere wasn't exactly welcoming. However, the ghost clansmen themselves got along famously, often enthusiastic in assisting and advising each other.
+The male consorts were mostly humans, with very few ghostmen among them, creating a distinct division between newcomers and veterans. The atmosphere wasn't exactly welcoming. However, the ghostman clansmen themselves got along famously, often enthusiastic in assisting and advising each other.
 
 “I have some news as well…” Ning Zhuo concisely summarized his recent conflict with the elderly steward to Sun Lingtong.
 

--- a/chapters/578.txt
+++ b/chapters/578.txt
@@ -20,7 +20,7 @@ Sun Lingtong gasped softly and promptly offered a respectful salute.
 
 Ning Zhuo also stepped into the room right after, bowing respectfully: "Lord Qing Yan!"
 
-The person waiting inside was none other than the Golden Core ghost cultivator Qing Yan, who had previously volunteered to aid White Paper City halfway through their journey.
+The person waiting inside was none other than the Golden Core ghostman cultivator Qing Yan, who had previously volunteered to aid White Paper City halfway through their journey.
 
 Qing Yan nodded upon seeing Ning Zhuo, stood up, and walked directly to him. "A riot broke out today, and the paper statue at the South Gate was destroyed."
 

--- a/chapters/579.txt
+++ b/chapters/579.txt
@@ -190,7 +190,7 @@ The steward’s sudden shout startled some into alertness.
 
 Sun and Ning followed the crowd and soon reached the Scripture Repository. Guided by the silver-robed steward, they entered in an orderly fashion.
 
-"Fetal Light Nether Fire Scripture" – Enables a cultivator to temper their Fetal Light soul and control Netherworld Ghost Fire.
+"Fetal Light Underworld Fire Scripture" – Enables a cultivator to temper their Fetal Light soul and control Underworld Ghost Fire.
 
 "Hidden Arrow Soul-Slayer Spear" – Allows a cultivator to transform their spine into a spear bone, unleashing soul-piercing screams during attacks, devastating to ghosts and souls alike.
 
@@ -228,7 +228,7 @@ To enter Radiant Yang Court or Yin-Yang Court, cultivators needed to practice ei
 
 Powerful practitioners could produce soul fragrances to please the White Paper City Lord, while the latter method allowed practitioners to harness Yin essence to bear ghostly offspring for the City Lord.
 
-Naturally, these offspring weren't human but members of the ghost race!
+Naturally, these offspring weren't human but members of the ghostman race!
 
 Ning Zhuo had yet to thoroughly cultivate his Three Supreme Methods, so he lacked interest in these new techniques, merely pretending to select one.
 

--- a/chapters/580.txt
+++ b/chapters/580.txt
@@ -6,7 +6,7 @@ He glanced at the burly, thick-bearded Yang Weida standing before him and recall
 
 Firstly, Yang Weida was a merchant hailing from the Flying Cloud Kingdom. It wasn’t unusual for him to deal in aphrodisiacs.
 
-Secondly, Qing Yan, the Golden Core cultivator of the ghost clan, had previously mentioned that Jiao Ma cultivated the Jiao family’s signature technique, the Three Furnace True Yang Scripture. It was precisely this scripture that made Jiao Ma abundantly vigorous, prompting Qing Yan to confidently predict that Jiao Ma would surely stand out among the male consorts.
+Secondly, Qing Yan, the Golden Core cultivator of the ghostman clan, had previously mentioned that Jiao Ma cultivated the Jiao family’s signature technique, the Three Furnace True Yang Scripture. It was precisely this scripture that made Jiao Ma abundantly vigorous, prompting Qing Yan to confidently predict that Jiao Ma would surely stand out among the male consorts.
 
 Considering these two points, Ning Zhuo nodded slightly and conveyed through spiritual sense to Yang Weida, “Then I’ll buy a little, just to test the effects.”
 
@@ -152,7 +152,7 @@ Although Hidden Yang Mansion had strict management rules requiring male consorts
 
 Passing through the middle courtyard, Sun Lingtong spotted a gathering of cultivators discussing something heatedly around a posted notice.
 
-Curious, Sun Lingtong approached but was immediately rebuked by a human male cultivator, “Ghost clan servant? Whose slave are you? Get lost, don’t come near us!”
+Curious, Sun Lingtong approached but was immediately rebuked by a human male cultivator, “Ghostman clan servant? Whose slave are you? Get lost, don’t come near us!”
 
 A sharp glint briefly flashed in Sun Lingtong’s eyes, but outwardly he bowed submissively and retreated, observing from afar.
 

--- a/chapters/581.txt
+++ b/chapters/581.txt
@@ -10,7 +10,7 @@ Only after he left the central courtyard did the male consorts break into heated
 
 “Alas, we humans must endure humiliation at the hands of this demon, how utterly embarrassing!”
 
-“It’s hardly our fault, is it? He’s a true disciple of the Seven Feathers Alliance, rumored to possess remnants of the Three-legged Golden Crow bloodline. His presence here at the Ghostly Black Marshlands is supposedly the fulfillment of a favor between the White-Headed Dragon Lord and the Seven Feathers Alliance. How could ordinary people like us contend with such an individual?”
+“It’s hardly our fault, is it? He’s a true disciple of the Seven Feathers Alliance, rumored to possess remnants of the Three-legged Golden Crow bloodline. His presence here at the Ghostly Black Marshlands is supposedly the fulfillment of a favor between the White-Haired Dragon Sovereign and the Seven Feathers Alliance. How could ordinary people like us contend with such an individual?”
 
 “Hidden Yang Manor indulges him excessively. When we wish to leave, we must report thrice, yet he merely informs the gatekeepers and strolls right out!”
 
@@ -18,7 +18,7 @@ Listening to their discussions, Sun Lingtong’s curiosity was piqued.
 
 The Seven Feathers Alliance was a superpower comparable to the Soul Devouring Sect and the Void Sect, but primarily composed of demonic cultivators. At its inception, it was formed by seven ancient spirit birds.
 
-The White-Headed Dragon Lord was notably a renowned Soul Formation cultivator within the Flying Cloud Country.
+The White-Haired Dragon Sovereign was notably a renowned Soul Formation cultivator within the Flying Cloud Country.
 
 Sun Lingtong glanced again at the bulletin, realizing it listed rankings based on Yang energy contributions among the male consorts of the Hidden Yang Manor. Only the top fifty were displayed; naturally, Jiao Ma (Ning Zhuo) wasn’t mentioned.
 
@@ -92,13 +92,13 @@ The mysterious cultivator flicked it away effortlessly, shattering it into fragm
 
 He continued, his voice echoing eerily. “I counted on your arrogance to draw me out, Jin Yangzi. Your pride is precisely what seals your doom!”
 
-In an instant, the alleyway vanished, replaced by a grand waterfall plunging into a deep, turbulent pool. This was his Domain - Hidden Scales of the Dragon Pool.
+In an instant, the alleyway vanished, replaced by a grand waterfall plunging into a deep, turbulent pool. This was his Dao Field - Hidden Scales of the Dragon Pool.
 
 Jin Yangzi’s eyes narrowed sharply as he quickly soared into the sky, avoiding the churning waters. Sun Lingtong, caught off guard, leaped onto a precarious rock in the pool, positioned awkwardly between the two powerful cultivators.
 
 Standing opposite Jin Yangzi at the pool’s edge, the mysterious cultivator unleashed his attack. With a wave of his hand, he summoned a dragon-shaped surge of water from the pool. The watery dragon lunged towards Jin Yangzi, who swiftly drew a long spear, its tip radiating brilliant light. A casual jab from the spear shattered the aquatic beast effortlessly.
 
-Jin Yangzi sneered contemptuously, “Your domain surprised me. You’re a devotee of the Hidden Scale Dragon Lord? Nevertheless, these petty attacks are barely worth my attention!”
+Jin Yangzi sneered contemptuously, “Your Dao Field surprised me. You’re a devotee of the Hidden Scale Dragon Lord? Nevertheless, these petty attacks are barely worth my attention!”
 
 “Is that so?” The mysterious cultivator smirked ominously, launching a flurry of water-based techniques. Yet, regardless of how cleverly the water twisted and took shape, Jin Yangzi dismissed each attack with mocking ease.
 
@@ -134,9 +134,9 @@ The mysterious cultivator grunted softly. A dragon’s resonant roar emanated fr
 
 Jin Yangzi clenched his teeth, helpless against the overwhelming power.
 
-“This is truly dire!” Sun Lingtong thought desperately. He had hoped Jin Yangzi might break free of the domain, providing a chance to escape. Instead, Jin Yangzi was thoroughly suppressed, sealing their grim fate.
+“This is truly dire!” Sun Lingtong thought desperately. He had hoped Jin Yangzi might break free of the Dao Field, providing a chance to escape. Instead, Jin Yangzi was thoroughly suppressed, sealing their grim fate.
 
-“Even if this is your domain, I still have recognition within White Paper Immortal City and remain unaffected by its grand formation!” Jin Yangzi glared fiercely at the mysterious cultivator. “You’re also at the Golden Core stage, yet you’re similarly unrestricted. Who exactly are you?!”
+“Even if this is your Dao Field, I still have recognition within White Paper Immortal City and remain unaffected by its grand formation!” Jin Yangzi glared fiercely at the mysterious cultivator. “You’re also at the Golden Core stage, yet you’re similarly unrestricted. Who exactly are you?!”
 
 The mysterious cultivator smiled chillingly. “The one who’ll end your life.”
 
@@ -150,9 +150,9 @@ After several exhausting cycles, Jin Yangzi gradually weakened, the golden glow 
 
 Sun Lingtong desperately attempted to flee amidst despair.
 
-But the mysterious cultivator didn’t even need to act personally. The domain alone sufficed to nullify Sun Lingtong’s escape, rendering his efforts completely futile.
+But the mysterious cultivator didn’t even need to act personally. The Dao Field alone sufficed to nullify Sun Lingtong’s escape, rendering his efforts completely futile.
 
-“Within this domain, any method used by my enemies is significantly weakened.”
+“Within this Dao Field, any method used by my enemies is significantly weakened.”
 
 “Little Zhuo, save me quickly!”
 
@@ -170,7 +170,7 @@ For a moment, he struggled to speak clearly.
 
 “Hmm?” The mysterious cultivator was astonished to see Sun Lingtong escape.
 
-“That technique was externally invoked and ignored the suppression of my domain. It seems like some sort of summoning method.”
+“That technique was externally invoked and ignored the suppression of my Dao Field. It seems like some sort of summoning method.”
 
 “No matter.”
 

--- a/chapters/583.txt
+++ b/chapters/583.txt
@@ -6,25 +6,25 @@ An emaciated old man glared at Ning Zhuo, snapping, “You’re the pockmarked b
 
 Ning Zhuo quickly cupped his hands respectfully, “Thank you for your help, senior.”
 
-“Hmph,” the old chef snorted arrogantly. Though his cultivation had stalled at the late Foundation Establishment stage throughout his life, his culinary skills as a spiritual chef were undeniably outstanding.
+“Hmph,” the Spirit Chef Elder snorted arrogantly. Though his cultivation had stalled at the late Foundation Establishment stage throughout his life, his culinary skills as a spiritual chef were undeniably outstanding.
 
 Ning Zhuo sat in front of the chef, attracting curious, envious, wary, and jealous gazes from many male consorts in the dining hall.
 
-The spiritual chef took out a massive bronze cauldron, pouring in copious amounts of water from the Nether Flood Dragon River. Channeling ghostly Netherfire with both hands, he heated the bronze vessel. Soon, the cauldron vibrated and boiled intensely, emitting steam that carried eerie sounds of ghostly wails and snake hisses, deeply unsettling.
+The Spirit Chef Elder took out a massive bronze cauldron, pouring in copious amounts of water from the Underworld Flood Dragon River. Channeling ghostly Netherfire with both hands, he heated the bronze vessel. Soon, the cauldron vibrated and boiled intensely, emitting steam that carried eerie sounds of ghostly wails and snake hisses, deeply unsettling.
 
 The chef then retrieved a piece of mystical tortoise shell, grinding it with a swift movement of his palms into bluish-gray powder. Adding this powder into the boiling water, he simmered the mixture briefly before dumping numerous other ingredients into the cauldron. Soon after, he ceased the Netherfire, completing the spiritual meal.
 
-Within the cauldron now lay a Netherworld Styx Broth, its surface deep and dark like inked jade. Upon closer inspection, twisted remnants of souls seemed to wriggle within.
+Within the cauldron now lay a Underworld Styx Broth, its surface deep and dark like inked jade. Upon closer inspection, twisted remnants of souls seemed to wriggle within.
 
 Ning Zhuo scooped a spoonful from the huge bronze cauldron and brought it to his lips. The moment the broth entered his mouth, it felt like swallowing rusted bronze shards, gritty and pungent. He barely managed to choke it down, a metallic tang lingering strongly in his throat.
 
 By the time he finished the entire cauldron of broth, Ning Zhuo’s lips and tongue had turned a bronze hue. Yet, his soul’s foundation experienced a tremendous surge. After several days of regularly consuming spiritual meals, his soul foundation had grown to three hundred times that of an ordinary person!
 
-The spiritual chef scrutinized Ning Zhuo, somewhat impressed yet also disgruntled, “Fine, at least you managed to finish everything, boy. But devouring it so quickly doesn’t give me any satisfaction - do you mean to suggest my cooking was actually delicious?”
+The Spirit Chef Elder scrutinized Ning Zhuo, somewhat impressed yet also disgruntled, “Fine, at least you managed to finish everything, boy. But devouring it so quickly doesn’t give me any satisfaction - do you mean to suggest my cooking was actually delicious?”
 
 His temper was indeed eccentric; pleased that Ning Zhuo finished the food, yet annoyed at the lack of torment from his dishes.
 
-“Now watch closely: my second dish!” The old chef declared, resuming his preparations.
+“Now watch closely: my second dish!” The Spirit Chef Elder declared, resuming his preparations.
 
 He brought forth a large cauldron, rapidly invoking lightning clouds and swirling purple energies within it. Chanting incantations, he threw in Mystic Bird Tear Crystals, swiftly slicing them into pieces with his palm and adding them to the cauldron. Using the martial arts technique Dragon Claw Hands, he continually struck the cauldron, tossing in more ingredients as he went.
 
@@ -54,13 +54,13 @@ The bloating pain in his stomach gradually subsided.
 
 Ning Zhuo ate slowly, accommodating his digestion, ultimately managing not to embarrass himself.
 
-Seeing that Ning Zhuo had finished the entire Three-Life Broken Tooth Pastry, the spiritual chef’s severe expression eased slightly, acknowledging, “You indeed qualify to savor my exquisite culinary creations.”
+Seeing that Ning Zhuo had finished the entire Three-Life Broken Tooth Pastry, the Spirit Chef Elder’s severe expression eased slightly, acknowledging, “You indeed qualify to savor my exquisite culinary creations.”
 
 Hearing “exquisite culinary creations,” Ning Zhuo couldn’t help but twitch at the corner of his eye.
 
 He had finally managed to consume five spiritual dishes, his belly swollen to the point where he could only sit half-reclined, enduring the surrounding gazes that were either envious or puzzled.
 
-Those envious admired Ning Zhuo’s willingness to expend his points for large quantities of Nether Meals, significantly enhancing his soul foundation.
+Those envious admired Ning Zhuo’s willingness to expend his points for large quantities of Underworld Meals, significantly enhancing his soul foundation.
 
 The puzzled ones wondered why he would waste points on soul-enhancing foods instead of pills to boost Yang energy, thereby achieving better rankings - a positive cycle most sought after. Why would Jiao Ma, who had merely “luckily” ranked forty-seventh, squander and slack off?
 
@@ -80,13 +80,13 @@ Therefore, he was highly motivated to rectify this glaring weakness.
 
 “I’m just at the Foundation Establishment stage, not yet at Golden Core. Low cultivation has its advantages - it allows me to easily strengthen areas my main techniques neglect through supplementary arts.”
 
-When his cultivation rose, such as reaching Golden Core, consuming these Nether Meals would yield drastically reduced benefits. The early stages of cultivation were precisely the optimal period for foundation building, an opportunity he must not miss.
+When his cultivation rose, such as reaching Golden Core, consuming these Underworld Meals would yield drastically reduced benefits. The early stages of cultivation were precisely the optimal period for foundation building, an opportunity he must not miss.
 
 “Jiao Ma, you’ve only been here briefly, yet you’re already ranked. How did you achieve that?”
 
 “Could you share some insights?”
 
-“You’re spending your hard-earned points on Nether Meals; aren’t you worried you’ll drop off the rankings?”
+“You’re spending your hard-earned points on Underworld Meals; aren’t you worried you’ll drop off the rankings?”
 
 Seeing Ning Zhuo reclining, some male concubines approached him in small groups, mingling envy and reluctance as they sought his advice.
 
@@ -174,7 +174,7 @@ Wen Ruanyu sighed in relief, appreciating Sorrowful Melody Ghost Seer’s foresi
 
 Sounds of chaos filtered into Hidden Yang Manor, causing the male consorts to anxiously whisper among themselves.
 
-On the public rankings, Ning Zhuo remained in the forties, silently consuming multiple servings of Nether Meals under the watchful eye of the elderly Spirit Chef.
+On the public rankings, Ning Zhuo remained in the forties, silently consuming multiple servings of Underworld Meals under the watchful eye of the elderly Spirit Chef.
 
 His soul strength had surpassed five hundred, now reaching nearly six hundred ninety times that of a normal cultivator.
 

--- a/chapters/584.txt
+++ b/chapters/584.txt
@@ -147,7 +147,7 @@ A day later.
 
 In the dining hall.
 
-Ning Zhuo sat upright, watching as the Spirit Chef Elder cooked Netherworld Cuisine before him.
+Ning Zhuo sat upright, watching as the Spirit Chef Elder cooked Underworld Cuisine before him.
 
 As usual, after consuming the dishes, Ning Zhuo felt his stomach swell, leaving him barely able to move.
 
@@ -157,7 +157,7 @@ As he digested the food, his soul foundation decisively surpassed a thousandfold
 
 Ning Zhuo smiled slightly, "It's all thanks to your assistance, Senior."
 
-The elder snorted coldly, "Stop flattering! Your achievement owes partly to your willingness to spend contributions specifically on my Netherworld dishes and partly to the city's policy adjustments which granted access to abundant rare ingredients. Usually, this would never happen."
+The elder snorted coldly, "Stop flattering! Your achievement owes partly to your willingness to spend contributions specifically on my Underworld dishes and partly to the city's policy adjustments which granted access to abundant rare ingredients. Usually, this would never happen."
 
 Ning Zhuo nodded, "I understand. The ghost tide has besieged the city for days."
 
@@ -173,11 +173,11 @@ This time, among the male consorts ascending into the Three Courts, Ning Zhuo wa
 
 This afternoon, it was Ning Zhuo’s turn to visit Sorrowful Melody Ghost Seer.
 
-The elderly Spirit Chef nodded gravely. "I've been in White Paper Immortal City for many years now. Keeping this city intact has been no easy task. Sorrowful Melody Ghost Seer has contributed greatly, especially now when even the City Lord is considering sealing herself away."
+The Spirit Chef Elder nodded gravely. "I've been in White Paper Immortal City for many years now. Keeping this city intact has been no easy task. Sorrowful Melody Ghost Seer has contributed greatly, especially now when even the City Lord is considering sealing herself away."
 
 Thinking back on recent battles, Ning Zhuo nodded in agreement. "That's very true."
 
-The Spirit Chef fixed Ning Zhuo with a serious gaze. "Jiao Ma, you're the first among the male consorts to persistently eat my Underworld Cuisine for so many days. You've got grit!"
+The Spirit Chef Elder fixed Ning Zhuo with a serious gaze. "Jiao Ma, you're the first among the male consorts to persistently eat my Underworld Cuisine for so many days. You've got grit!"
 
 "Moreover, you're from a village outside the city; White Paper Immortal City is your home."
 
@@ -185,17 +185,17 @@ The Spirit Chef fixed Ning Zhuo with a serious gaze. "Jiao Ma, you're the first 
 
 Surprised, Ning Zhuo responded honestly, "Actually... I'm more inclined to venture outside and see the wider world."
 
-The elderly Spirit Chef snorted, visibly displeased, but still handed over a jade slip and a token.
+The Spirit Chef Elder snorted, visibly displeased, but still handed over a jade slip and a token.
 
 "Spirit cooking is among the hundred cultivation arts, with its own traditions and rules."
 
-"This inheritance I give you must not be shared carelessly. Learn it or not, it’s your choice. But if you do, remember: you belong to the Dark Cuisine Sect, and you must carry forth this legacy!"
+"This inheritance I give you must not be shared carelessly. Learn it or not, it’s your choice. But if you do, remember: you belong to the Dark Cuisine School, and you must carry forth this legacy!"
 
 "Within the jade slip are my cultivation methods, recipes, and insights. The token signifies your sect and your identity. When participating in the Hundred Kingdoms Culinary Competition in the future, this will be your entrance and participant credential."
 
 Ning Zhuo hadn’t expected that simply eating Underworld Cuisine for several days would yield him an unexpected Spirit Chef inheritance.
 
-Though appearing fierce, the elderly chef had clearly taken a liking to Ning Zhuo.
+Though appearing fierce, the Spirit Chef Elder had clearly taken a liking to Ning Zhuo.
 
 Thinking it wise to have more skills at hand, the clever young man considered briefly before seriously agreeing.
 

--- a/chapters/585.txt
+++ b/chapters/585.txt
@@ -184,13 +184,13 @@ Spiritual Energy like a knife directly cut open Sang Le Youling's belly, and als
 
 Seeing the large amount of residual spirit food in the stomach, Ning Zhuo's guarded heartstring relaxed slightly.
 
-He cupped his hands and said: "Lord City Lord, Lady Sang Le Youling treated herself by consuming Nether Meals. And these Nether Meals are difficult to digest, and one cannot use spiritual energy to aid digestion, otherwise eating them would be pointless."
+He cupped his hands and said: "Lord City Lord, Lady Sang Le Youling treated herself by consuming Underworld Meals. And these Underworld Meals are difficult to digest, and one cannot use spiritual energy to aid digestion, otherwise eating them would be pointless."
 
 "After lunch, according to the arrangement, I was the first male consort to have an audience with Lady Sang Le Youling."
 
 "If I had killed Sang Le Youling, it must have been not long ago."
 
-"But the undigested spirit food in Sang Le Youling's abdomen proves that she died earlier, not long after finishing the Nether Meal, she was attacked and killed!"
+"But the undigested spirit food in Sang Le Youling's abdomen proves that she died earlier, not long after finishing the Underworld Meal, she was attacked and killed!"
 
 Everyone fell silent.
 
@@ -200,6 +200,6 @@ Sun Lingtong was delighted: "Little Zhuo, that makes sense!"
 
 Wen Ruanyu frowned.
 
-Ning Zhuo let out a turbid breath: "I had no time to commit the crime, because at that time, I was in the dining hall of Cang Yang Biefu, consuming Nether Meal on the spot. Many people witnessed this scene!"
+Ning Zhuo let out a turbid breath: "I had no time to commit the crime, because at that time, I was in the dining hall of Cang Yang Biefu, consuming Underworld Meal on the spot. Many people witnessed this scene!"
 
 The paper avatar snorted coldly, killing intent still lingering: "The deduction is not bad. However, you still cannot completely clear your suspicion. Who exactly are you?"

--- a/chapters/587.txt
+++ b/chapters/587.txt
@@ -214,7 +214,7 @@ In his view: Yuan Dasheng was obviously a mechanism; being able to display such 
 
 "This doesn't quite match the intelligence." Wen Ruanyu sighed.
 
-Ghost Technique - Nether Soul Cast Iron.
+Ghost Technique - Underworld Soul Cast Iron.
 
 Butcher Ghost General cried out, performed the ghost technique, his overall defense greatly increased. Yuan Dasheng's punches and kicks hitting him produced sounds of metal striking.
 

--- a/chapters/588.txt
+++ b/chapters/588.txt
@@ -62,7 +62,7 @@ Ning Zhuo had no intention of revealing his true identity.
 
 Currently, only two people in White Paper Immortal City knew his true identity.
 
-Because of the unknown factor that the Twin Ghosts of Haven and Earth posed, Ning Zhuo did not want to expose his real identity.
+Because of the unknown factor that the Twin Ghosts of Heaven and Earth posed, Ning Zhuo did not want to expose his real identity.
 
 Wen Ruanyu did not dwell on this point, but continued: "Therefore, probably don't know, but the arrangements Senior Sister Meng left in White Paper Immortal City profoundly changed the structure of this city and protected it many times."
 
@@ -145,7 +145,7 @@ The paper clone paused for a moment, then smiled lightly: "On this point, you ar
 "But before that, I still have many secrets I need to tell you."
 
 "'Ghost tides surge, White Paper in peril,
-A lone goose carries a candle, piercing heaven’s veil.
+A lone goose carries a candle, piercing heavenl's veil.
 The guest star appears in the north of the literary pivot,
 Myriad Manifestations Lamp ignites, shattering calamity.' 
 

--- a/chapters/589.txt
+++ b/chapters/589.txt
@@ -131,11 +131,11 @@ Deep within the Water Burial Valley.
 
 Ash Bone Elder sat cross-legged, slowly opened his eyes, gazing with a complex expression at the piece of skullcap before him.
 
-This was the skullcap of a Sky Ghost, a treasure material of the Void Refining level!
+This was the skullcap of a Heavenly Ghost, a treasure material of the Void Refining level!
 
 Now, the surface of the skullcap had been refined by the Prefecture Lord until it melted like liquid, but the inside remained stubborn bone matter.
 
-"No wonder, Prefecture Lord, you spared no expense, painstakingly refining this piece of Sky Ghost bone."
+"No wonder, Prefecture Lord, you spared no expense, painstakingly refining this piece of Heavenly Ghost bone."
 
 "This superior innate talent complements you perfectly, Prefecture Lord, no, it seems almost a match made in heaven."
 
@@ -143,17 +143,17 @@ The Prefecture Lord laughed heartily: "If it weren't so, why would I go to such 
 
 After obtaining this skullcap, he studied it carefully, and discovered nearly half a divine ability remained within it. After painstakingly planning for over a hundred years, continuously investing manpower and resources, he finally saw signs of imminent success this year.
 
-Within the Sky Ghost skullcap, only a small portion of bone matter remained.
+Within the Heavenly Ghost skullcap, only a small portion of bone matter remained.
 
 As long as he completely refined it, the Prefecture Lord would be able to fully absorb it, adding a new innate talent to himself!
 
-The Prefecture Lord sighed with emotion: "To obtain this innate talent, I have truly taken great pains. Just to obtain the Sky Ghost Transformation Sacrifice Ritual, it cost thirty percent of my prefecture's treasury, to trade for it from another prefecture."
+The Prefecture Lord sighed with emotion: "To obtain this innate talent, I have truly taken great pains. Just to obtain the Heavenly Ghost Transformation Sacrifice Ritual, it cost thirty percent of my prefecture's treasury, to trade for it from another prefecture."
 
 Ash Bone Elder was silent for a moment, then said: "This ritual originates from Confucianism, sacrificing to Heaven and Earth, in the Underworld it is considered virtue, in the Yang world it is considered sin. Therefore, it has caused countless calamities and blood debts in White Paper Immortal City."
 
 The Prefecture Lord sneered: "Those who achieve great things don't sweat the small stuff, I am a king of the Underworld, do I still need the morality of the Yang world?"
 
-"White Paper Immortal City, I must eliminate it, the entire city will be used for a blood sacrifice, only then can my Sky Ghost Transformation ritual be completed!"
+"White Paper Immortal City, I must eliminate it, the entire city will be used for a blood sacrifice, only then can my Heavenly Ghost Transformation ritual be completed!"
 
 Ash Bone Elder sighed: "Therefore, this skullcap is the source of the calamity. I used the calamity Qi within it to perform the Calamity Ash Covering Divination technique, but I also calculated that you are still facing obstacles on your path to success."
 
@@ -177,7 +177,7 @@ Ash Bone Elder said: "It's actually simple, according to my divination technique
 
 "Prefecture Lord, you are the esteemed ruler of a prefecture, placed in the Yang world, you would naturally be the ruler of a nation, extraordinarily powerful and noble."
 
-"But this Sky Ghost Transformation Sacrifice Ritual covers both the Yin and Yang realms. Your position in the Underworld is stable, unbreakable, but in the Yang world, it is a major shortcoming."
+"But this Heavenly Ghost Transformation Sacrifice Ritual covers both the Yin and Yang realms. Your position in the Underworld is stable, unbreakable, but in the Yang world, it is a major shortcoming."
 
 "To win in the Yang world, it is necessary to overcome the strongest currents of fate there, only then can success be achieved."
 

--- a/chapters/591.txt
+++ b/chapters/591.txt
@@ -104,7 +104,7 @@ Though the entire process was painstakingly slow, it radiated a sense of relentl
 
 Ning Zhuo calmed his heart and observed attentively, feeling his heart shudder once again: “This is the innate power of White Paper Immortal City itself!”
 
-It was this very immortal city quietly weaving together paper armies within the netherworld.
+It was this very immortal city quietly weaving together paper armies within the Underworld.
 
 At this pace, forming just a single army would require decades.
 

--- a/chapters/593.txt
+++ b/chapters/593.txt
@@ -196,7 +196,7 @@ Sun Lingtong chuckled softly, "The Yang Realm..."
 
 Luo Si gave him a profound look, "Brother, if you wish to explore the Yang Realm, the Ghostly Black Marshlands are indeed an excellent place."
 
-"Years ago, there was a Netherworld Flood Dragon, incredibly talented and brilliantly insightful. It created the 'Yin-Yang Wheel Sutra,' aiming to defy fate by transforming Yin into Yang. It nearly succeeded during its heavenly tribulation but failed at the last moment, meeting a tragic end due to divine punishment."
+"Years ago, there was a Underworld Flood Dragon, incredibly talented and brilliantly insightful. It created the 'Yin-Yang Wheel Sutra,' aiming to defy fate by transforming Yin into Yang. It nearly succeeded during its heavenly tribulation but failed at the last moment, meeting a tragic end due to divine punishment."
 
 "After its death, its powers reshaped an entire region, forcibly linking Yin and Yang to create a treasure trove of unique energy."
 

--- a/chapters/594.txt
+++ b/chapters/594.txt
@@ -138,7 +138,7 @@ On the reverse side, etched in vermilion ink, was the complete “Thirteen Chapt
 
 Luo Si nodded. “Many have come seeking the black snow, as it can deepen one’s cultivation and foundations. But where does the black snow come from?”
 
-“It’s the result of the Heavenly Ghost Birth Sacrifice, presided over by the Lord of the Underworld Palace.”
+“It’s the result of the Heavenly Ghost Transformation Sacrifice Ritual, presided over by the Lord of the Underworld Palace.”
 
 “This rite draws on yang to nourish yin and has earned the praise of the heavens of the Underworld. It can enhance one’s foundations without backlash.”
 

--- a/chapters/595.txt
+++ b/chapters/595.txt
@@ -26,7 +26,7 @@ This was perfectly reasonable.
 
 In today’s cultivation world, methods and doctrines blossomed abundantly, and military strategies had reached remarkable sophistication. Concealed marches were the norm, while overtly powerful maneuvers like Iron Torrent Sweeping the Plains were rare.
 
-The Underworld’s domain, analogous to powerful cultivation kingdoms in the mortal realm, naturally had elite formations and tactics. If Sun and Ning could so easily breach their secrecy, that would be utterly ridiculous.
+The Underworld’s prefecture, analogous to powerful cultivation kingdoms in the mortal realm, naturally had elite formations and tactics. If Sun and Ning could so easily breach their secrecy, that would be utterly ridiculous.
 
 After all, both of them were merely Foundation Establishment cultivators, far from capable of miraculous feats.
 
@@ -44,7 +44,7 @@ To gather intelligence once again, Sun Lingtong boldly antagonized six Golden Co
 
 Of course, it wasn’t reckless bravado.
 
-Observing outside the chariot, Sun Lingtong noted the impeccable discipline and rigid order of the ghost troops - undoubtedly elite soldiers from the Underworld Domain of Forgetfulness.
+Observing outside the chariot, Sun Lingtong noted the impeccable discipline and rigid order of the ghost troops - undoubtedly elite soldiers from the Underworld Prefecture of Forgetful River.
 
 Just as one should exploit a gentleman’s righteousness, Sun Lingtong inferred that internal conflict would be harshly penalized, especially with battle imminent.
 
@@ -80,7 +80,7 @@ As he spoke, the Crimson-haired Ghost General blew out a stream of fiery breath,
 
 The ghostly flames penetrated straight into Sun Lingtong’s very soul, scorching him from within. Agony seized every fiber of his being, causing him to tremble violently, yet he gritted his teeth and endured without uttering a sound.
 
-The Crimson-haired Ghost General squinted, a cruel smile spreading across his lips. “Does it feel good? My Netherworld Ghost Flames can directly burn the soul, bringing you some warmth, eh?”
+The Crimson-haired Ghost General squinted, a cruel smile spreading across his lips. “Does it feel good? My Underworld Ghost Flames can directly burn the soul, bringing you some warmth, eh?”
 
 Following him, the Green-faced Ghost General unleashed another sinister move. Patches of corpse moss began sprouting across Sun Lingtong’s tortured body.
 
@@ -152,7 +152,7 @@ They made a beeline toward the paper statue near the southern gate, prepared to 
 
 Just as they were about to strike, a youthful voice suddenly rang out, “Activate the formation!”
 
-Instantly, twenty-eight luminous musical script arrays surfaced on the ground, revealing twelve gleaming Blue Nether Jade Marrow Nails hidden deep underground.
+Instantly, twenty-eight luminous musical script arrays surfaced on the ground, revealing twelve gleaming Blue Underworld Jade Marrow Nails hidden deep underground.
 
 Four robust bronze pillars emerged, topped by statues of Azure Phoenixes with golden strings clutched in their beaks, each dangling seven exquisite bells. Tiny runes densely covered the bells - astonishingly, each bell bore the entire “Profound Cave Spirit Tone Ghoul-Exterminating Spell” meticulously engraved upon it!
 

--- a/chapters/596.txt
+++ b/chapters/596.txt
@@ -26,7 +26,7 @@ On the city wall, Tie Guzheng, commander of the City Guard, glared fiercely at t
 
 He longed to lead a decisive charge outside the city to slaughter the Ghost Mothers but hesitated upon spotting the formidable ghostly army further away.
 
-Unlike previous ghost tides, this time the Netherworld Court of Forgotten River had dispatched actual elite troops!
+Unlike previous ghost tides, this time the Underworld Prefecture of Forgetful River had dispatched actual elite troops!
 
 Undoubtedly, this posed an unprecedented challenge to Tie Guzheng.
 

--- a/chapters/597.txt
+++ b/chapters/597.txt
@@ -104,23 +104,23 @@ He shook the command token.
 
 In the next moment, a ghost flew out from the token.
 
-This ghost quickly materialized into a solid form. He was thin and wiry, with three mouths on his face. It was an old acquaintance - Three-Mouth Ghost General.
+This ghost quickly materialized into a solid form. He was thin and wiry, with three mouths on his face. It was an old acquaintance - Blabbermouth Ghost General.
 
-Unlike before, Three-Mouth Ghost General was now clad in a suit of paper armor. His skin was also inscribed with many white characters. These characters were very small, but they were interlinked to form chain-like patterns that covered his entire body.
+Unlike before, Blabbermouth Ghost General was now clad in a suit of paper armor. His skin was also inscribed with many white characters. These characters were very small, but they were interlinked to form chain-like patterns that covered his entire body.
 
-"This humble one greets Young Master Jiao Ma." Three-Mouth Ghost General bowed on his own initiative. Clearly, he had been instructed in advance.
+"This humble one greets Young Master Jiao Ma." Blabbermouth Ghost General bowed on his own initiative. Clearly, he had been instructed in advance.
 
-Even without any prior instruction, Ning Zhuo’s terrifying performance on the battlefield had already deeply shocked Three-Mouth Ghost General.
+Even without any prior instruction, Ning Zhuo’s terrifying performance on the battlefield had already deeply shocked Blabbermouth Ghost General.
 
-So in front of Ning Zhuo, Three-Mouth Ghost General was timid and cautious, completely lacking the presence of a Golden Core level figure.
+So in front of Ning Zhuo, Blabbermouth Ghost General was timid and cautious, completely lacking the presence of a Golden Core level figure.
 
 Ning Zhuo gave him a brief glance, then turned his focus to Wen Ruanyu. "Is such a surrender truly reliable?"
 
-"Reliable, reliable, reliable!" Three-Mouth Ghost General quickly pledged his loyalty.
+"Reliable, reliable, reliable!" Blabbermouth Ghost General quickly pledged his loyalty.
 
 "Shut up." Ning Zhuo glanced at him.
 
-Three-Mouth Ghost General trembled and lowered his head immediately. "Yes, yes, yes."
+Blabbermouth Ghost General trembled and lowered his head immediately. "Yes, yes, yes."
 
 Wen Ruanyu gave a bitter smile. "Jiao Ma, do you know how much battle strength our city lost in this round of internal and external turmoil?"
 
@@ -134,7 +134,7 @@ Wen Ruanyu continued, "This ghost tide is different from before."
 
 "Therefore, this may become a prolonged war. We must maintain a fighting force in order to have any hope of enduring this tribulation."
 
-Wen Ruanyu first explained the necessity of recruiting enemy generals, then added, "Three-Mouth Ghost General is already quite trustworthy."
+Wen Ruanyu first explained the necessity of recruiting enemy generals, then added, "Blabbermouth Ghost General is already quite trustworthy."
 
 "On one hand, the paper armor on him is a restriction cast by Madam City Lord. On the other hand, he also bears the Confucian technique, the ‘Amnesty and Alliance Policy’."
 

--- a/chapters/598.txt
+++ b/chapters/598.txt
@@ -78,7 +78,7 @@ He even added some of his own understanding: “Etiquette is not hypocrisy, but 
 
 Ning Zhuo gained much from this and hastily cupped his hands in thanks.
 
-He recalled the earlier scene at the Nether Flood-Dragon River when Wen Ruanyu engaged in battle. His mastery of etiquette had indeed been profound, causing many water ghosts and underworld soldiers to lay down their weapons and begin speaking of manners, surrendering themselves.
+He recalled the earlier scene at the Underworld Flood Dragon River when Wen Ruanyu engaged in battle. His mastery of etiquette had indeed been profound, causing many water ghosts and underworld soldiers to lay down their weapons and begin speaking of manners, surrendering themselves.
 
 “Benevolence, Righteousness, Etiquette, Wisdom, Trust... with Benevolence, Righteousness, and Etiquette already branded, only Wisdom and Trust remain.”
 

--- a/chapters/599.txt
+++ b/chapters/599.txt
@@ -166,7 +166,7 @@ Once her burden lightened enough, the City Lord would be able to act again.
 
 Wen Ruanyu sighed. “Originally, Master Jin Yangzi was the best candidate for the task.”
 
-“He was planted here by the White-Haired Dragon Lord. We all knew it, but for the greater good, we held our tongues.”
+“He was planted here by the White-Haired Dragon Sovereign. We all knew it, but for the greater good, we held our tongues.”
 
 “Unfortunately, the traitor moved first and took him out.”
 
@@ -246,7 +246,7 @@ She wore tight-fitting leather armor that accentuated her curves - full chest, s
 
 The girl came straight to him, locking eyes with Ning Zhuo, her gaze intense and burning. “Little Ma, you still love me, don’t you?”
 
-Ning Zhuo immediately understood - this must be Qing Chi, the daughter of Qing Qan. She was the ghost-tribe girl who’d once been in love with Jiao Ma.
+Ning Zhuo immediately understood - this must be Qing Chi, the daughter of Qing Qan. She was the ghostman girl who’d once been in love with Jiao Ma.
 
 His head throbbed. He shook it, expression cold. “What’s the point in talking about love now? Just leave. And don’t come back. From now on, let’s pretend we never met.”
 

--- a/chapters/600.txt
+++ b/chapters/600.txt
@@ -28,7 +28,7 @@ Seeing that her emotions were becoming increasingly agitated, Ning Zhuo immediat
 
 "Alright." Qing Chi said immediately, "Let's go inside and talk!"
 
-How could Ning Zhuo dare to let her into the room, continuing to block the doorway: "I'll send you a flying letter, it's not appropriate to say anything here, after all, this is the Virility Enhancement Courtyard."
+How could Ning Zhuo dare to let her into the room, continuing to block the doorway: "I'll send you a flying letter, it's not appropriate to say anything here, after all, this is Vigorous Yang Manor."
 
 "Perhaps, when it's convenient for both of us, we can arrange a time and place to properly clarify some things."
 
@@ -64,7 +64,7 @@ He immediately frowned: "That's right! Her father, Qing Yan, doesn't want you tw
 
 "The Jiao family is still counting on you to climb up and establish a closer relationship with the City Lord, so naturally, they would never tell Qing Chi your location."
 
-"But Qing Chi not only found the Virility Enhancement Courtyard, but without asking around, she directly found your residence. You know, how long have you just moved into the Virility Enhancement Courtyard?"
+"But Qing Chi not only found Vigorous Yang Manor, but without asking around, she directly found your residence. You know, how long have you just moved into Vigorous Yang Manor?"
 
 "This might be someone with ulterior motives who quietly told Qing Chi."
 
@@ -126,7 +126,7 @@ Ning Zhuo immediately frowned, pretending to be surprised: "Ah, no way? Who woul
 
 Yang Weida: "There are many."
 
-"Jiao Ma, you've just arrived at the Virility Enhancement Courtyard, you don't quite understand the situation here."
+"Jiao Ma, you've just arrived at Vigorous Yang Manor, you don't quite understand the situation here."
 
 "I entered the courtyard a little earlier than you and found out that the three most powerful male concubines here are Shen Bing, Chen Sui, and Sun Tiesheng."
 
@@ -214,7 +214,7 @@ Sun Lingtong: "Yes, the mechanism ring warned us, there's a problem with that oi
 
 "According to what we knew before, he was suspected of being a savior. So, before even entering the city, he was investigated."
 
-"The Sorrowful Ghost Melody Seer must have done her best to examine him."
+"Sorrowful Ghost Melody Seer must have done her best to examine him."
 
 Ning Zhuo nodded: "If I were the Lord of the River of Oblivion, or the City Overturning Alliance, I wouldn't dispatch a traitor like a traveling merchant at this juncture."
 
@@ -260,7 +260,7 @@ Ning Zhuo smiled faintly and convinced him with just one sentence: "As long as t
 
 Wen Ruanyu clapped his hands and laughed: "Exactly so, Young Master Jiao Ma has thought it through! Let's proceed with this plan."
 
-Thus, that very night, the Virility Enhancement Courtyard implemented a lockdown and announced an important matter – the Virility Enhancement Courtyard would set up a Spirit Contract Treasure Refining Formation.
+Thus, that very night, Vigorous Yang Manor implemented a lockdown and announced an important matter – Vigorous Yang Manor would set up a Spirit Contract Treasure Refining Formation.
 
 This formation was quite classic, capable of lowering the standard for a magic treasure to recognize its owner, reducing the difficulty of refining, and allowing the magic treasure to recognize its owner more quickly.
 
@@ -270,7 +270,7 @@ Whoever refined the Golden Swallow Fork could activate the immense yang qi withi
 
 And the male concubine who could accomplish this would naturally achieve a monstrous merit and ascend to a high position in one fell swoop!
 
-The Virility Enhancement Courtyard distributed formation flags, so that every male concubine had a formation footing to station themselves at, fully releasing their yang qi, to compete and vie for the identity of the magic treasure's owner.
+Vigorous Yang Manor distributed formation flags, so that every male concubine had a formation footing to station themselves at, fully releasing their yang qi, to compete and vie for the identity of the magic treasure's owner.
 
 A night passed.
 

--- a/chapters/601.txt
+++ b/chapters/601.txt
@@ -62,15 +62,15 @@ Ning Zhuo was curious.
 
 Wen Ruanyu shared the hidden truth.
 
-"There’s a saying - ‘the land shapes the people.’ The ghost clans have lived and bred in this region for generations. Their nature is shadowy, combative - more like savages than anything else. In the beginning, they were impossible to manage. Peaceful coexistence with the human race was out of the question."
+"There’s a saying - ‘the land shapes the people.’ The ghostman clans have lived and bred in this region for generations. Their nature is shadowy, combative - more like savages than anything else. In the beginning, they were impossible to manage. Peaceful coexistence with the human race was out of the question."
 
-"What you see today - the social structure of White Paper Immortal City and the ghostfolk villages across this mist-laden marshland - it's all thanks to the Ink Pool."
+"What you see today - the social structure of White Paper Immortal City and the ghostman villages across this mist-laden marshland - it's all thanks to the Ink Pool."
 
 "We altered the composition of the Ink Pool's waters, turning it into the main drinking source for the city and surrounding settlements."
 
-"Over time, that water infused the ghostfolk with a sense of culture. Their violent instincts dulled. They became gentler, more refined. Only then could we open schools and academies, teach them language and knowledge, and help them flourish."
+"Over time, that water infused the ghostmen with a sense of culture. Their violent instincts dulled. They became gentler, more refined. Only then could we open schools and academies, teach them language and knowledge, and help them flourish."
 
-"Of course, the ghostfolk resisted. For a long time, they tried every means to sabotage the Ink Pool - and they succeeded, more than once."
+"Of course, the ghostmen resisted. For a long time, they tried every means to sabotage the Ink Pool - and they succeeded, more than once."
 
 Ning Zhuo listened intently, a new question forming in his mind.
 
@@ -82,7 +82,7 @@ Wen Ruanyu nodded without hesitation.
 
 "When I first followed her here, it was a desolate place. Barely inhabited. The ambient yin energy was overwhelming - almost like the underworld itself. And the ghost tides made it even worse. What sane cultivator would willingly settle here?"
 
-"Humans made up the bulk of the population. Ghostfolk were few, and due to their cruel, violent nature, they were watched closely - most of them lived as slaves."
+"Humans made up the bulk of the population. Ghostmen were few, and due to their cruel, violent nature, they were watched closely - most of them lived as slaves."
 
 "Senior Sister Meng was born with a compassionate heart. She treated all beings with equal respect. That’s what I admired most about her."
 
@@ -90,33 +90,33 @@ Wen Ruanyu nodded without hesitation.
 
 Ning Zhuo’s eyes lit up.
 
-"She planned to use the power of the ghostfolk?"
+"She planned to use the power of the ghostmen?"
 
 Wen Ruanyu chuckled.
 
 "Exactly."
 
-"The ghostfolk are half-yin, half-yang - perfectly attuned to this marshland."
+"The ghostmen are half-yin, half-yang - perfectly attuned to this marshland."
 
-"They’re far better suited to life here than humans. They can even enter the Netherworld Flood Dragon River and explore the underworld itself."
+"They’re far better suited to life here than humans. They can even enter the Underworld Flood Dragon River and explore the underworld itself."
 
 "But their numbers and strength were kept tightly suppressed by human cultivators. And there weren’t enough humans here to govern the region on their own. Senior Sister Meng saw that as a tremendous waste."
 
-"So she consulted us, and ultimately chose a Confucian path - establishing the Ink Pool to civilize the ghostfolk. To free them from their savage ways and make them the true backbone of this land’s governance."
+"So she consulted us, and ultimately chose a Confucian path - establishing the Ink Pool to civilize the ghostmen. To free them from their savage ways and make them the true backbone of this land’s governance."
 
 A surge of admiration rose in Ning Zhuo’s heart. “This Senior Meng… she’s incredible. ‘The water shapes the people,’ and she actually changed the water to reshape the culture of this entire region. That kind of foresight and vision truly commands respect.”
 
 He turned to Wen Ruanyu. “But of course, without your perseverance and dedication, Senior Wen, there would be no such success in civilizing White Paper Immortal City.”
 
-Wen Ruanyu was clearly pleased, both by Ning Zhuo’s reverence for Meng Yaoyin and his praise of himself. “It’s precisely thanks to the long-term influence of the Ink Pool that we were able to gradually loosen our restrictions on the ghostkin. We supported them, encouraged their growth, and employed them as the primary labor force to build up this shadowy, damp marshland.”
+Wen Ruanyu was clearly pleased, both by Ning Zhuo’s reverence for Meng Yaoyin and his praise of himself. “It’s precisely thanks to the long-term influence of the Ink Pool that we were able to gradually loosen our restrictions on the ghostmen. We supported them, encouraged their growth, and employed them as the primary labor force to build up this shadowy, damp marshland.”
 
-“I oversaw city governance, and deliberately developed a network of villages and towns around the city. Each one is rooted in a few human cultivators, with the majority of the population being ghostkin.”
+“I oversaw city governance, and deliberately developed a network of villages and towns around the city. Each one is rooted in a few human cultivators, with the majority of the population being ghostmen.”
 
 “Today, our sphere of influence spans forty percent of the marshland.”
 
 “This time, when White Paper Immortal City faced the threat of destruction, the City Lord gave a single command - and so many forces rushed to our aid. I can’t deny I felt deeply gratified.”
 
-“Granted, some of that is due to the generous rewards offered by the City Lord. But it also proves that our teachings have truly taken root. Human or ghostkin alike, their hearts are aligned with White Paper Immortal City.”
+“Granted, some of that is due to the generous rewards offered by the City Lord. But it also proves that our teachings have truly taken root. Human or ghostman alike, their hearts are aligned with White Paper Immortal City.”
 
 This conversation gave Ning Zhuo a much deeper understanding of the city's history.
 

--- a/chapters/602.txt
+++ b/chapters/602.txt
@@ -134,9 +134,9 @@ That very night -
 
 Beyond the walls of White Paper Immortal City.
 
-A squad of ghost cultivators suddenly burst out from underground, surrounding a team of yin soldier scouts.
+A squad of ghostman cultivators suddenly burst out from underground, surrounding a team of yin soldier scouts.
 
-“Die!” shouted a young ghost clan girl named Qing Chi. She charged headlong into the fray, her small frame slamming into a skeletal warhorse, shattering bone and throwing its rider to the ground.
+“Die!” shouted a young ghostman girl named Qing Chi. She charged headlong into the fray, her small frame slamming into a skeletal warhorse, shattering bone and throwing its rider to the ground.
 
 Bang! Bang! Bang!
 
@@ -146,13 +146,13 @@ Seeing their leader in danger, the other ghost soldiers lunged toward Qing Chi -
 
 Qing Chi killed the squad leader, then sprang to her feet. Her eyes blazed with fierce light, battle-lust burning like fire as she turned to look for her next opponent.
 
-But what she saw was her father and the rest of the ghost cultivators finishing off the last of the scout soldiers.
+But what she saw was her father and the rest of the ghostman cultivators finishing off the last of the scout soldiers.
 
 They had already wiped out the whole patrol.
 
 Qing Chi stood there, caught mid-motion, and shouted in frustration, “Hey! Leave some for me!”
 
-The ghost cultivators chuckled and teased, “Come on, young miss. You’re gunning for merit so you can impress your sweetheart. But we want achievements too. We can’t just hand over the credit.”
+The ghostman cultivators chuckled and teased, “Come on, young miss. You’re gunning for merit so you can impress your sweetheart. But we want achievements too. We can’t just hand over the credit.”
 
 Qing Chi snorted. “Suit yourselves. When we run into real enemies, let’s see who can steal kills from me!”
 
@@ -212,9 +212,9 @@ As the two walked off, they continued drawing glances.
 
 “So that’s Qing Chi?”
 
-“The ghost clan girl who’s been making waves lately. Still Foundation Establishment, but already fighting at Golden Core level!”
+“The ghostman girl who’s been making waves lately. Still Foundation Establishment, but already fighting at Golden Core level!”
 
-“Her flame teems with life force - pure poison to ghostkind.”
+“Her flame teems with life force - pure poison to ghosts.”
 
 Driven to fight with everything she had just for a chance to see her beloved, the young girl had stunned the battlefield and become the brightest star of the city’s defense.
 
@@ -256,7 +256,7 @@ Sun Lingtong refused once more, then changed the topic to something more amusing
 
 During his cultivation, Ning Zhuo never checked in on Sun Lingtong’s situation. But as part of the ghost army, Sun had witnessed Qing Chi’s fierce brilliance in battle.
 
-He warned Ning Zhuo, “That girl’s a real fighter! Even our side’s paying attention now. If she keeps growing like this, her blue flame will be a nightmare for ghostkind. We’ve already compiled a ton of intel on her.”
+He warned Ning Zhuo, “That girl’s a real fighter! Even our side’s paying attention now. If she keeps growing like this, her blue flame will be a nightmare for ghosts. We’ve already compiled a ton of intel on her.”
 
 “You’re in that intel too.”
 

--- a/chapters/603.txt
+++ b/chapters/603.txt
@@ -8,7 +8,7 @@ Meng Yaoyin's voice came from the Interwoven Field Paths Lantern, but it resonat
 
 With those words came a massive influx of information, flooding Ning Zhuo’s mind.
 
-Sky Ghost Transformation Sacrifice Ritual… the skull of the Sky Ghost… postnatal aptitude… choosing White Paper Immortal City as a blood sacrifice… to offer tribute to Yin Heaven…
+Heavenly Ghost Transformation Sacrifice Ritual… the skull of the Heavenly Ghost… postnatal aptitude… choosing White Paper Immortal City as a blood sacrifice… to offer tribute to Yin Heaven…
 
 Moments later, Ning Zhuo fully absorbed the astonishing revelations. His eyes gleamed with sharp light. “So that’s what it is!”
 
@@ -56,7 +56,7 @@ Ning Zhuo mused aloud, “It’s possible. But we’ll need to meet Ash Bone Eld
 
 “Boss,” Ning Zhuo said with a chuckle, “looks like you’ll have to postpone your Golden Core breakthrough again.”
 
-Sun Lingtong fell silent for a moment, then gave a bitter laugh. “No helping it! Now that we know the truth, I’ll have to double down on my soul cultivation too. I need to push my soul foundation to Million Man Soul - only then will I be qualified to disrupt the Sky Ghost Transformation Sacrifice Ritual.”
+Sun Lingtong fell silent for a moment, then gave a bitter laugh. “No helping it! Now that we know the truth, I’ll have to double down on my soul cultivation too. I need to push my soul foundation to Million Man Soul - only then will I be qualified to disrupt the Heavenly Ghost Transformation Sacrifice Ritual.”
 
 Ning Zhuo had already reached the threshold of a million souls. Sun Lingtong now resolved to do the same, to serve as a second line of defense.
 
@@ -178,7 +178,7 @@ It was crafted from black jade, three inches and seven-tenths long, glowing with
 
 The front bore the complete Four-Seal Sigil of Yama at its center, ringed around the edges by illustrations of the Eighteen Hells.
 
-The back was inscribed with cinnabar script, containing the Thirteen Chapters of the Nether Code.
+The back was inscribed with cinnabar script, containing the Thirteen Chapters of the Underworld Code.
 
 It was none other than the Heaven-bestowed Talisman!
 
@@ -212,17 +212,17 @@ Ning Zhuo’s eyes lit up. “What’s in the chant?”
 
 “I’ve memorized most of it,” Sun Lingtong said, then began to recite:
 
-“In reverence we offer to the Sovereign of the Lunar Throne, light cast down from the Nine Netherworlds. The Yanluo Kings hold the laws, binding souls across the ten directions of the Netherworld. Snow surges from the Yellow Springs; spirits cross through myriad tribulations in the vastness beyond.
+“In reverence we offer to the Sovereign of the Lunar Throne, light cast down from the Nine Underworlds. The Yanluo Kings hold the laws, binding souls across the ten directions of the Underworld. Snow surges from the Yellow Springs; spirits cross through myriad tribulations in the vastness beyond.
 
-Now, by the Sky Ghost Transformation Sacrifice Ritual, we offer devotion to the Yin Heaven’s Master...
+Now, by the Heavenly Ghost Transformation Sacrifice Ritual, we offer devotion to the Underworld Heaven’s Master...
 
-We present the Sacred Seal of the Four Corners at the Black Altar, arrayed in the true images of the Eighteen Hells as our veil. Black snow cloaks the ground sevenfold, nurturing the Yin Fiend with Yang soul. Cinnabar scripts the Ninefold Transformation of Heaven, invoking the Nether Law to pierce the void...
+We present the Sacred Seal of the Four Corners at the Black Altar, arrayed in the true images of the Eighteen Hells as our veil. Black snow cloaks the ground sevenfold, nurturing the Yin Fiend with Yang soul. Cinnabar scripts the Ninefold Transformation of Heaven, invoking the Underworld Law to pierce the void...
 
 We beseech the Yin Heavens to open a swift path through the Underworld, to cleanse the festering sins of lost souls. Grant us the Celestial Talisman, to anchor the soul’s origin at the Spirit Terrace. May...
 
 ...with humble rites and solemn words, we entreat you to partake!”
 
-Ning Zhuo’s face lit up with joy. “That must be the Grand Rite Invocation for the Sky Ghost Transformation Sacrifice Ritual. Big Brother, memorize the whole thing carefully - there might be a clue in there that could help us crack this entire situation open.”
+Ning Zhuo’s face lit up with joy. “That must be the Grand Rite Invocation for the Heavenly Ghost Transformation Sacrifice Ritual. Big Brother, memorize the whole thing carefully - there might be a clue in there that could help us crack this entire situation open.”
 
 Sun Lingtong shook his head. “Neither of us is a scholar-cultivator. Trying to find a loophole in a ritual text like this? That’s a long shot - don’t get your hopes up.”
 

--- a/chapters/605.txt
+++ b/chapters/605.txt
@@ -102,7 +102,7 @@ A herd of skeletal white deer struggled bitterly below. Their leader, the Stag K
 
 The Wolf King saw its moment - and leapt!
 
-Its claws tore through the air like blades, and its fangs shimmered with the ghostly glow of the netherworld.
+Its claws tore through the air like blades, and its fangs shimmered with the ghostly glow of the underworld.
 
 The Stag King, already at the end of its strength, couldn’t guard against the ambush. The Wolf King’s jaws clamped down on its throat.
 
@@ -304,7 +304,7 @@ The patriarch’s tone turned contemplative. “Given how things stand, with Che
 
  - 
 
-Netherworld.
+Underworld.
 
 Water Burial Valley.
 

--- a/chapters/606.txt
+++ b/chapters/606.txt
@@ -134,9 +134,9 @@ Ash Bone Elder’s ash avatar responded crisply through spiritual transmission.
 
 “Fortunately, we’ve also spent many years preparing. We are not acting rashly.”
 
-“When the Sky Ghost Transformation Sacrifice Ritual concludes, the Sky Ghost Skull will be fully refined. We must disrupt the ritual before that moment arrives.”
+“When the Heavenly Ghost Transformation Sacrifice Ritual concludes, the Heavenly Ghost Skull will be fully refined. We must disrupt the ritual before that moment arrives.”
 
-“To break through to the altar of the Sky Ghost Transformation Sacrifice Ritual at the final moment, three conditions must be met. Let me explain them in detail.”
+“To break through to the altar of the Heavenly Ghost Transformation Sacrifice Ritual at the final moment, three conditions must be met. Let me explain them in detail.”
 
 “First, the soul foundation of at least one million souls.”
 
@@ -162,11 +162,11 @@ The ash figure let out a hearty laugh, shook its head, and replied through spiri
 
 “I am a cultivator of divination. I walk the path of prophecy, guided by the will of Heaven and Earth. My discipline seeks to unveil the hidden workings of fate.”
 
-“The Sky Ghost has long perished, and now they intend to forcibly resurrect it, even if only partially. That alone is a violation of the natural order. That’s the first reason.”
+“The Heavenly Ghost has long perished, and now they intend to forcibly resurrect it, even if only partially. That alone is a violation of the natural order. That’s the first reason.”
 
 “The Forgetful River Prefecture Lord is already immensely gifted. As ruler of this region, he should have accepted his limits - but he is not content. He wants more, to go beyond what fate allows. That’s the second reason.”
 
-“To refine the Sky Ghost Skull, he devised the Sky Ghost Transformation Sacrifice Ritual. He intends to bribe the Underworld’s heavens by sacrificing something belonging to the heavens of the living world - namely, the entirety of White Paper Immortal City. Such an act is demonic in nature and a gross affront to the celestial order. That’s the third reason.”
+“To refine the Heavenly Ghost Skull, he devised the Heavenly Ghost Transformation Sacrifice Ritual. He intends to bribe the Underworld’s heavens by sacrificing something belonging to the heavens of the living world - namely, the entirety of White Paper Immortal City. Such an act is demonic in nature and a gross affront to the celestial order. That’s the third reason.”
 
 “He once used a personal favor to coerce me. Then he entered the valley himself and forced me to conceal the fate of White Paper Immortal City. Now he’s even found a way to imprison me here in Water Burial Valley. That’s the fourth.”
 
@@ -274,7 +274,7 @@ Director Zheng wore a troubled expression. “Given how firmly Sun Tiesheng has 
 
 Li Xiangshang faced a dilemma.
 
-Sun Tiesheng was practically the only viable candidate. If he refused, how could Li Xiangshang complete the task assigned by the Dragon King?
+Sun Tiesheng was practically the only viable candidate. If he refused, how could Li Xiangshang complete the task assigned by the Dragon Sovereign?
 
 He turned to Director Zheng for advice. After a moment’s thought, the director said, “The Sun Clan’s current stance is simply because they believe there’s no other competition.”
 

--- a/chapters/607.txt
+++ b/chapters/607.txt
@@ -72,7 +72,7 @@ After a long pause, he looked up at Li Xiangshang, his expression somewhat confl
 
 Then he turned to his daughter - and sure enough, saw her watching him with hopeful eyes.
 
-The old father let out a long sigh. “I’ve never had high hopes for the two of them. One’s from the human race, the other from the ghost race. That kind of future is hard.”
+The old father let out a long sigh. “I’ve never had high hopes for the two of them. One’s from the human race, the other from the ghostman race. That kind of future is hard.”
 
 Qing Chi immediately retorted, “But there are plenty of couples in our village from both races!”
 
@@ -158,7 +158,7 @@ Qing Chi moved across the ravaged battlefield, her footsteps trailing green fire
 
 Their injuries closed up rapidly, and they looked on in astonishment.
 
-Many among them were of the ghost race, with bodies that held both yang energy and deathly yin energy. This was fundamentally different from the human cultivators.
+Many among them were of the ghostman race, with bodies that held both yang energy and deathly yin energy. This was fundamentally different from the human cultivators.
 
 And yet, Qing Chi’s flames - clearly brimming with life force - somehow stimulated their regenerative abilities without disrupting their yin-based cultivation.
 
@@ -286,7 +286,7 @@ Qing Chi stood tall, her chest puffed out with pride, as she stirred the beginni
 
 Li Xiangshang added, “We’ve already reported to the City Lord and received her approval. Miss Qing has now been officially appointed Deputy Commander of the City Guard.”
 
-Ning Zhuo stared hard at Qing Chi, his gaze sharp enough to pierce through the ghost-clan girl standing before him.
+Ning Zhuo stared hard at Qing Chi, his gaze sharp enough to pierce through the ghostman girl standing before him.
 
 At last, he spoke slowly. “The first step in forming an army… is forging its spirit. That’s no easy feat.”
 

--- a/chapters/608.txt
+++ b/chapters/608.txt
@@ -124,7 +124,7 @@ Sun Lingtong responded immediately, “I’m all in - both hands, both feet in f
 
 After everything they’d been through, both of them had come to truly appreciate just how formidable divination arts could be. The temptation was real.
 
-In the Underworld, Sun Lingtong was leading his cavalry deeper into the heartlands of Forgetful River’s domain.
+In the Underworld, Sun Lingtong was leading his cavalry deeper into the heartlands of Forgetful River Prefecture.
 
 His goal: to find Luo Si and seek further assistance.
 

--- a/chapters/609.txt
+++ b/chapters/609.txt
@@ -14,17 +14,17 @@ Tie Guezheng sat in command with a grim expression.
 
 His experience in defense was formidable, and he directed the troops with unshakable calm. With him as the central pillar, the City Guard held fast to the battlements, refusing to yield even a single step.
 
-Human cultivators and ghostfolk alike manned sections of the wall, supporting the City Guard as auxiliary forces and doing their part to hold the line.
+Human cultivators and ghostmen alike manned sections of the wall, supporting the City Guard as auxiliary forces and doing their part to hold the line.
 
-Suddenly, a Ghost Yaksha soared onto the battlements and slew two ghostfolk defenders, securing a foothold on the wall.
+Suddenly, a Ghost Yaksha soared onto the battlements and slew two ghostman defenders, securing a foothold on the wall.
 
 It had to be eliminated quickly. The longer it held its position, the more ghosts would rally to it, creating a forward stronghold. If that happened, this section of the wall would inevitably fall.
 
-“Get down from there!” a ghost cultivator shouted, charging the Ghost Yaksha with all his strength.
+“Get down from there!” a ghostman cultivator shouted, charging the Ghost Yaksha with all his strength.
 
-But after just two clashes, the ghost cultivator’s head was lopped off.
+But after just two clashes, the ghostman cultivator’s head was lopped off.
 
-More ghostfolk reinforcements rushed forward, hoping to drive it off. Some were wounded, others killed. None succeeded.
+More ghostman reinforcements rushed forward, hoping to drive it off. Some were wounded, others killed. None succeeded.
 
 “It’s at the Golden Core level! Only a Golden Core can take it down!”
 
@@ -32,7 +32,7 @@ More ghostfolk reinforcements rushed forward, hoping to drive it off. Some were 
 
 “Hurry!”
 
-A ghostfolk cultivator shouted the alarm.
+A ghostman cultivator shouted the alarm.
 
 In the short time it took to speak, five or six more ghost creatures had already climbed onto the wall, forming up around the Ghost Yaksha.
 
@@ -40,7 +40,7 @@ This trend was disastrous.
 
 The more ghosts established themselves on the battlements, the harder it would be to reclaim the position.
 
-“No need to call for help. I’ll handle it.” At that critical moment, a young ghost folk girl leapt into the sky.
+“No need to call for help. I’ll handle it.” At that critical moment, a young ghostman girl leapt into the sky.
 
 It was Qing Chi!
 
@@ -188,7 +188,7 @@ Li Xiangshang replied, “That depends on the individual. Some achieve it in mom
 
 He looked at Qing Chi again. “In your case, I estimate it won’t take long.”
 
-“First, the Qing Clan ghost troops are quite simple in structure, and their numbers are small - only two to three hundred.”
+“First, the Qing Clan ghostman troops are quite simple in structure, and their numbers are small - only two to three hundred.”
 
 “Second, they have full faith in you. The will of the troops is aligned with yours. That makes all the difference.”
 
@@ -252,7 +252,7 @@ Qing Chi’s heart raced. “That’s a brilliant idea!”
 
 “I’ll grow stronger. I’ll lead my troops. I’ll win Jiao Ma back!”
 
-The ghost-clan girl clenched her fists, eyes full of resolve.
+The ghostman girl clenched her fists, eyes full of resolve.
 
 Her motivation now fully ignited, she threw herself into the task of mastering military intelligence.
 

--- a/chapters/615.txt
+++ b/chapters/615.txt
@@ -146,7 +146,7 @@ Speaking of which, Qing Chi's comprehension of the Military System had spurred N
 
 While Qing Chi had no prior experience with military strategy, Ning Zhuo possessed the accumulated knowledge of two major national wars and two treasures of the Military Strategist school: Gao Sheng's Lost Writings and the Ancient Shared - Battle Armor.
 
-He was eager to use these treasures to aid him, but unfortunately, he had yet to fully master the Heroic Return Technique. Only upon achieving complete mastery could he wield the Ancient Shared - Battle Armor.
+He was eager to use these treasures to aid him, but unfortunately, he had yet to fully master the Hero's Return Technique. Only upon achieving complete mastery could he wield the Ancient Shared - Battle Armor.
 
 Sun Lingtong, on the other hand, was ready. However, Ning Zhuo currently had more pressing matters. Sun Lingtong's mere presence within the enemy ranks, providing crucial military intelligence, was already invaluable and irreplaceable.
 
@@ -184,9 +184,9 @@ Setting down his cup, he shifted the conversation: "Brother Jiao, are you aware 
 
 "Oh?" Ning Zhuo had heard rumors of this. He turned to Yang Weida. "Your intelligence network is quite thorough."
 
-Yang Weida shook his head with a wry smile. "Brother Jiao, as I mentioned before, my elder brother is Yang Third Eye, a True Inheritor disciple of the Myriad Manifestations Sect. My access to information merely stems from leveraging the sect's local branch here - nothing remarkable."
+Yang Weida shook his head with a wry smile. "Brother Jiao, as I mentioned before, my elder brother is Yang Sanyan, a True Inheritor disciple of the Myriad Manifestations Sect. My access to information merely stems from leveraging the sect's local branch here - nothing remarkable."
 
-Though he claimed it was "nothing remarkable," he meticulously reiterated Yang Third Eye's name and status.
+Though he claimed it was "nothing remarkable," he meticulously reiterated Yang Sanyan's name and status.
 
 Yang Weida fixed Ning Zhuo with a piercing gaze. "Given the Qing-Jiao Army's influence and your standing with the Lord City Master, I'm certain you've known about this for some time. Yet you've taken no action, seemingly content to let Sun Tiesheng succeed?"
 
@@ -278,7 +278,7 @@ He had succeeded.
 
 The fork emitted a warm golden light that bathed Sun Tiesheng's entire body.
 
-Sun Tiesheng's appearance had transformed. No longer purely Human Clan, he now possessed narrow, elongated eyes and golden-tipped eyebrows.
+Sun Tiesheng's appearance had transformed. No longer purely Human, he now possessed narrow, elongated eyes and golden-tipped eyebrows.
 
 The surrounding crowd erupted in cheers and congratulations.
 

--- a/chapters/616.txt
+++ b/chapters/616.txt
@@ -90,7 +90,7 @@ Wen Ruanyu was equally incredulous. "From his hands? Are you absolutely certain?
 
 Wen Ruanyu was the first to defend the suspect.
 
-This was because the man was an elder of White Paper Immortal City, a veteran Spirit Chef of the Dark Cuisine Sect, and the very elder who had gifted Ning Zhuo his Spirit Chef inheritance.
+This was because the man was an elder of White Paper Immortal City, a veteran Spirit Chef of the Dark Cuisine School, and the very elder who had gifted Ning Zhuo his Spirit Chef inheritance.
 
 Soon, the Spirit Chef Elder was brought before Wen Ruanyu and Ning Zhuo.
 

--- a/chapters/617.txt
+++ b/chapters/617.txt
@@ -1,4 +1,4 @@
-Chapter 617: Yang Third Eye, the Arrogant One
+Chapter 617: Yang Sanyan, the Arrogant One
 
 The yin wind howled, carrying countless ghostly figures.
 
@@ -242,7 +242,7 @@ Dressed in a dark azure Daoist robe, he stood as straight as a pine tree, his ha
 
 His jade-like face bore a tightly closed vertical mark between his brows, his eyes blazing with undisguised contempt and fury.
 
-Supreme talent - Utter Disdain for All!
+Supreme talent - All Under my Gaze is Emptiness!
 
 In the next instant, the vertical mark on his forehead split open, revealing a third, vertically oriented eye.
 
@@ -254,27 +254,27 @@ The vertical eye on the forehead of the three-eyed cultivator swept across the s
 
 He turned and swept his gaze across the left flank of the wall. All ghostly creatures and yin winds disappeared from that section as well.
 
-"Yang Third Eye of the Myriad Manifestations Sect's Demon Subduing Hall is here," the young cultivator announced, his voice cold and brimming with arrogance.
+"Yang Sanyan of the Myriad Manifestations Sect's Demon Subduing Hall is here," the young cultivator announced, his voice cold and brimming with arrogance.
 
 All the cultivators on the wall turned to look, their faces filled with surprise, shock, and awe. In an instant, their morale soared!
 
-Qing Chi stared curiously at Yang Third Eye, who stood just a few feet away.
+Qing Chi stared curiously at Yang Sanyan, who stood just a few feet away.
 
 In the distance, the Vanguard General of the Underworld Army pondered for a moment, then sighed and ordered, "Retreat."
 
-These three cultivators possessed astonishing power, each at the Golden Core level. But Yang Third Eye was even more extraordinary, displaying combat prowess that hinted at the Nascent Soul realm!
+These three cultivators possessed astonishing power, each at the Golden Core level. But Yang Sanyan was even more extraordinary, displaying combat prowess that hinted at the Nascent Soul realm!
 
-Yang Third Eye's vertical eye snapped shut. He turned slightly, extended his right hand, and wordlessly reached for Qing Chi.
+Yang Sanyan's vertical eye snapped shut. He turned slightly, extended his right hand, and wordlessly reached for Qing Chi.
 
 Qing Chi's hair stood on end, and she instinctively retreated to create distance.
 
-But in the next instant, Yang Third Eye's hand clamped down on her shoulder.
+But in the next instant, Yang Sanyan's hand clamped down on her shoulder.
 
 "Ghostman Clan girl, don't go running off!"
 
 Qing Yan paled in terror and immediately dropped to one knee, signaling his allegiance.
 
-Yang Third Eye snorted coldly. "If not for that, you'd already be dead. My brother mentioned you in his letter, along with someone named Jiao Ma."
+Yang Sanyan snorted coldly. "If not for that, you'd already be dead. My brother mentioned you in his letter, along with someone named Jiao Ma."
 
 "He told me he had sworn loyalty to Jiao Ma."
 
@@ -282,29 +282,29 @@ Yang Third Eye snorted coldly. "If not for that, you'd already be dead. My broth
 
 "How did Jiao Ma protect my brother? You're close to him - go fetch him here. He will answer for my brother's death!"
 
-Qing Chi struggled, but Yang Third Eye swiftly subdued her completely.
+Qing Chi struggled, but Yang Sanyan swiftly subdued her completely.
 
 Her eyes widened in disbelief. Even with the Military Power Amplification bolstering her strength, she couldn't resist him at all!
 
 Helpless, Qing Yan gritted his teeth. "Please wait here, Lord. I will summon Young Master Jiao Ma immediately."
 
-"Make him come pay his respects to me at once." Yang Third Eye strode away, carrying Qing Chi like a kitten. His towering frame dwarfed her petite form, making her look utterly helpless in his grasp.
+"Make him come pay his respects to me at once." Yang Sanyan strode away, carrying Qing Chi like a kitten. His towering frame dwarfed her petite form, making her look utterly helpless in his grasp.
 
-Yang Third Eye strode onto the city gate tower, immediately driving away the cultivator stationed there. He planted himself in the main seat with an air of authority, casually tossing Qing Chi at his feet.
+Yang Sanyan strode onto the city gate tower, immediately driving away the cultivator stationed there. He planted himself in the main seat with an air of authority, casually tossing Qing Chi at his feet.
 
 He ceased fighting, leaving Zhou Wenyan of the All-Book Pavilion and Bone Tomb Daoist of the Soul Devouring Sect to swiftly eliminate the remaining ghostly creatures.
 
-Seeing the battle resolved, Tie Guzheng thanked Zhou Wenyan and Bone Tomb Daoist before approaching Yang Third Eye to pay his respects.
+Seeing the battle resolved, Tie Guzheng thanked Zhou Wenyan and Bone Tomb Daoist before approaching Yang Sanyan to pay his respects.
 
-"Incompetent fool," Yang Third Eye snapped without acknowledging him. "Go oversee the city's defenses and don't bother me."
+"Incompetent fool," Yang Sanyan snapped without acknowledging him. "Go oversee the city's defenses and don't bother me."
 
 The only person he wished to see was Jiao Ma.
 
 Soon, led by Qing Yan, Ning Zhuo arrived at the city gate tower.
 
-Qing Yan used his divine sense to urgently warn Jiao Ma, "Remember your manners. Yang Third Eye is from the Myriad Manifestations Sect, with extraordinary power and status. More importantly, Qing Chi is still in his hands."
+Qing Yan used his divine sense to urgently warn Jiao Ma, "Remember your manners. Yang Sanyan is from the Myriad Manifestations Sect, with extraordinary power and status. More importantly, Qing Chi is still in his hands."
 
-"Hmph, so you're Jiao Ma? Give me..." Yang Third Eye sneered, but his words were cut short.
+"Hmph, so you're Jiao Ma? Give me..." Yang Sanyan sneered, but his words were cut short.
 
 Boom!
 

--- a/chapters/618.txt
+++ b/chapters/618.txt
@@ -34,7 +34,7 @@ In the next instant, Yang Sanyan snorted coldly, braced his arms, and unleashed 
 
 Ning Zhuo formed a sword-like gesture with his fingers, held them upright before his chest, and exhaled a bolt of golden lightning.
 
-Metal Element - Mythic Gold Slash!
+Metal Element - Mystic Gold Slash!
 
 Metal Element Lung Temple!
 
@@ -50,7 +50,7 @@ Ning Zhuo also withdrew his attack, focusing on controlling the remaining two fi
 
 Yang Sanyan watched Qing Chi's rescue without making any move to intervene.
 
-The Mythic Gold Slash, amplified by the army's power, had reached the Nascent Soul level of strength. Even Yang Sanyan's prized defensive techniques had failed to withstand it.
+The Mystic Gold Slash, amplified by the army's power, had reached the Nascent Soul level of strength. Even Yang Sanyan's prized defensive techniques had failed to withstand it.
 
 Yang Sanyan, a Golden Core cultivator, could unleash Nascent Soul-level combat power, making him renowned for his martial prowess within the Myriad Manifestations Sect. Yet the yellow-faced youth before him, merely at the Foundation Establishment stage, had just unleashed an attack of Nascent Soul caliber.
 
@@ -60,7 +60,7 @@ Even more striking to Yang Sanyan was Ning Zhuo's combat aptitude.
 
 "He possesses methods to amplify spells, yet when casting the Fire Dragon Technique, he deliberately held back, calculating that I wouldn't intercept it prematurely. Only when the attack was imminent did he suddenly amplify its power."
 
-"But that was merely a feint. When he unleashed the Mythic Gold Slash, he repeated the trick, simultaneously employing two amplification methods to catch me completely off guard."
+"But that was merely a feint. When he unleashed the Mystic Gold Slash, he repeated the trick, simultaneously employing two amplification methods to catch me completely off guard."
 
 "Most notably, the second amplification involved military power. This means he's already a member of the Qing-Jiao Army."
 
@@ -86,7 +86,7 @@ Throughout his time in White Paper Immortal City, Ning Zhuo had never stopped ga
 
 Having heard Qing Yan's account of Yang Sanyan's pride, Ning Zhuo acted decisively when the situation turned unfavorable.
 
-The Mythic Gold Slash could have struck Yang Sanyan directly, but Ning Zhuo deliberately aimed wide, intending only to demonstrate his strength.
+The Mystic Gold Slash could have struck Yang Sanyan directly, but Ning Zhuo deliberately aimed wide, intending only to demonstrate his strength.
 
 Yang Sanyan quickly recognized the reality of the situation and immediately changed his attitude.
 

--- a/chapters/621.txt
+++ b/chapters/621.txt
@@ -114,7 +114,7 @@ Li Xiangshang had been sent by the White-Haired Dragon Sovereign.
 
 As Ning Zhuo considered this, he gained a new understanding of the White Paper Immortal City's bewildering situation.
 
-The true grand scheme was the Forgetful River Prefecture Lord's century-old conspiracy. Under the Sky Ghost Transformation Sacrifice Ritual, the White Paper Immortal City had already been designated as a blood sacrifice site.
+The true grand scheme was the Forgetful River Prefecture Lord's century-old conspiracy. Under the Heavenly Ghost Transformation Sacrifice Ritual, the White Paper Immortal City had already been designated as a blood sacrifice site.
 
 "My mother learned of this through Ash Bone Elder, but he didn't inform the White Paper City Lord."
 
@@ -144,7 +144,7 @@ Therefore, he decisively chose to stand with the Myriad Manifestations Sect.
 
 "This question is crucial!"
 
-"If she is, I absolutely won't risk participating in the Sky Ghost Transformation Sacrifice Ritual."
+"If she is, I absolutely won't risk participating in the Heavenly Ghost Transformation Sacrifice Ritual."
 
 According to Yang Sanyan's account, Ning Zhuo's mother was likely murdered by a mysterious organization. This meant that the message left by Meng Yaoyin was inferior in level to this organization.
 

--- a/chapters/623.txt
+++ b/chapters/623.txt
@@ -26,7 +26,7 @@ Ning Zhuo suddenly recalled the dangerous maneuver he had witnessed during the g
 
 Realizing the severity of the situation, he exclaimed, "So the Yin Soldier army is actively preparing for a decisive battle!"
 
-"This Yin Soldier army initially stationed here was relatively small. But after enduring so many Ghost Tides, continuously absorbing ghostly creatures, and receiving reinforcements from the Forgetful River Domain, their numbers have now approached a hundred thousand!"
+"This Yin Soldier army initially stationed here was relatively small. But after enduring so many Ghost Tides, continuously absorbing ghostly creatures, and receiving reinforcements from the Forgetful River Prefecture, their numbers have now approached a hundred thousand!"
 
 "If they launch a full-scale assault, can the White Paper Immortal City withstand it?"
 
@@ -36,9 +36,9 @@ Although he held the title of Vice City Lord, the White Paper City Lord had neve
 
 At most, he knew that the Paper Giant possessed Nascent Soul-level combat strength.
 
-"The true key to this great battle lies not in the White Paper Immortal City, but in the Forgetful River Domain!"
+"The true key to this great battle lies not in the White Paper Immortal City, but in the Forgetful River Prefecture!"
 
-Due to Meng Yaoyin's arrangements, Ning Zhuo had access to comprehensive intelligence. However, he had not revealed details about the Sky Ghost Transformation Sacrifice Ritual or the Forgetful River Prefecture Lord's century-long scheme.
+Due to Meng Yaoyin's arrangements, Ning Zhuo had access to comprehensive intelligence. However, he had not revealed details about the Heavenly Ghost Transformation Sacrifice Ritual or the Forgetful River Prefecture Lord's century-long scheme.
 
 Keeping these secrets intact did not hinder the White Paper City Lord, Yang Sanyan, Wen Ruanyu, and others from actively preparing their defenses.
 
@@ -214,9 +214,9 @@ When Ning Zhuo gave the number, Qing Chi's face paled. He stared at the Spirit F
 
 With a twisted expression, Qing Chi swallowed the Spirit Food, experiencing both pain and a strange sense of satisfaction.
 
-These Spirit Foods were highly effective yet incredibly unpalatable, crafted by the Spirit Chef of the Dark Cuisine Sect.
+These Spirit Foods were highly effective yet incredibly unpalatable, crafted by the Spirit Chef Elder of the Dark Cuisine School.
 
-It turned out that when the Spirit Chef had initially agreed to the City Lord Clone's request to confess and use his life to stabilize the citizens' morale, Ning Zhuo had later uncovered the Internal Traitor, indirectly saving the elder's life.
+It turned out that when the Spirit Chef Elder had initially agreed to the City Lord Clone's request to confess and use his life to stabilize the citizens' morale, Ning Zhuo had later uncovered the Internal Traitor, indirectly saving the elder's life.
 
 After learning of this, the elder immediately sought out Ning Zhuo, expressing his desire to repay this life-saving grace by offering his humble services.
 
@@ -263,8 +263,8 @@ Qing Chi was surprised again. Looking at the table full of spirit food, she said
 
 Ning Zhuo shook his head.
 
-When it came to the final battle, this was nothing. Moreover, Ning Zhuo had already obtained the approval of the White Paper City Lord and the Spirit Chef.
+When it came to the final battle, this was nothing. Moreover, Ning Zhuo had already obtained the approval of the White Paper City Lord and the Spirit Chef Elder.
 
-The spirit food was prepared by the Spirit Chef, and the meal expenses were covered by the White Paper City Lord.
+The spirit food was prepared by the Spirit Chef Elder, and the meal expenses were covered by the White Paper City Lord.
 
 Ning Zhuo had simply been responsible for persuading both of them earlier.


### PR DESCRIPTION
- Three-Mouth Ghost General -> Blabbermouth Ghost General (it seems I missed a few correction last time?)
- Ghost -> Ghostman (manually vetted chapters 550 up to 610 and changed ghost to ghostman(adjective) or ghostmen(plural) depending on whether it's referring to native inhabitants of the Ghostly Black Marshlands, as they are distinct/different from the ghosts of the underworld)
- Heaven Ghost -> Sky Ghost (in the context of the skull. Different from Heavenly Ghost of Twin Ghosts of Heavens and Earth)
- Netherworld -> Underworld (only in White Paper Immortal City arc. Stuff like Netherworld Envoy Qi Bai is left alone)
- Virility Enhancement Hall -> Vigorous Yang Manor
- Dragon King -> Dragon Sovereign (in ch 606)
- Five Elements Transformation -> Scorched Earth Transformation (ch 423 mentioned by Lich)
- Yang Third Eye -> Yang Sanyan
- Utter Disdain for All -> All Under my Gaze is Emptiness
- Profound Gold Slash and Mythic Gold Slash -> Mytstic Gold Slash
- Variations of Hero's Return Technique -> Hero's Return Technique
- Standardized to Little Thief's Light Breeze Formation and Light Body Swift Wind Formation (called the former pre-ch-483 and the latter post-ch-483)
- Old Chef and Spirit Chef -> Spirit Chef Elder (vetted in context of each chapter starting from ch 583)
- Sky Ghost -> Heavenly Ghost
- Forgetful River Domain -> Forgetful River Prefecture
- domain -> Dao Field (ch 581)